### PR TITLE
feat: Add blackbox-exporter Flux OCI deployment

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,6 @@
 {
   "oci/altinn-uptime": "1.4.0",
   "oci/dis-tls-cert": "2.3.0",
-  "oci/whoami": "0.2.0"
+  "oci/whoami": "0.2.0",
+  "oci/blackbox-exporter": "0.5.1"
 }

--- a/oci/blackbox-exporter/CHANGELOG.md
+++ b/oci/blackbox-exporter/CHANGELOG.md
@@ -1,0 +1,64 @@
+# Changelog
+
+## [0.5.1](https://github.com/Altinn/altinn-platform/compare/flux-oci-blackbox-exporter-v0.5.0...flux-oci-blackbox-exporter-v0.5.1) (2025-12-08)
+
+
+### Bug Fixes
+
+* Add probes, PDB and resources to blackbox-exporter ([#2780](https://github.com/Altinn/altinn-platform/issues/2780)) ([a83b6b2](https://github.com/Altinn/altinn-platform/commit/a83b6b27b0676801eeae589bdf685463305c2a99))
+
+## [0.5.0](https://github.com/Altinn/altinn-platform/compare/flux-oci-blackbox-exporter-v0.4.5...flux-oci-blackbox-exporter-v0.5.0) (2025-12-08)
+
+
+### Features
+
+* Add TLS probe support for extra targets altinn-uptime ([#2768](https://github.com/Altinn/altinn-platform/issues/2768)) ([ab241e8](https://github.com/Altinn/altinn-platform/commit/ab241e8dd29e52fb3c449677a114a83f32047cf0))
+
+## [0.4.5](https://github.com/Altinn/altinn-platform/compare/flux-oci-blackbox-exporter-v0.4.4...flux-oci-blackbox-exporter-v0.4.5) (2025-12-04)
+
+
+### Bug Fixes
+
+* altinn uptime cronjob timeout ([#2727](https://github.com/Altinn/altinn-platform/issues/2727)) ([cc8bc03](https://github.com/Altinn/altinn-platform/commit/cc8bc03746487db001bdcded0f42feab557491dc))
+
+## [0.4.4](https://github.com/Altinn/altinn-platform/compare/flux-oci-blackbox-exporter-v0.4.3...flux-oci-blackbox-exporter-v0.4.4) (2025-12-04)
+
+
+### Bug Fixes
+
+* Increase blackbox-exporter timeouts to 10s ([#2698](https://github.com/Altinn/altinn-platform/issues/2698)) ([3b7da0c](https://github.com/Altinn/altinn-platform/commit/3b7da0c9f179cb4965a6068fb7e3a54bbb3faf90))
+
+## [0.4.3](https://github.com/Altinn/altinn-platform/compare/flux-oci-blackbox-exporter-v0.4.2...flux-oci-blackbox-exporter-v0.4.3) (2025-12-03)
+
+
+### Bug Fixes
+
+* Blackbox-exporter Inline HelmRelease patch in kustomization ([#2676](https://github.com/Altinn/altinn-platform/issues/2676)) ([cecae2d](https://github.com/Altinn/altinn-platform/commit/cecae2d02c07a405b6d1f6a80858d07a0030be45))
+
+## [0.4.2](https://github.com/Altinn/altinn-platform/compare/flux-oci-blackbox-exporter-v0.4.1...flux-oci-blackbox-exporter-v0.4.2) (2025-12-03)
+
+
+### Bug Fixes
+
+* Unwrap HelmRelease patch and remove README deploy ([#2668](https://github.com/Altinn/altinn-platform/issues/2668)) ([57862a5](https://github.com/Altinn/altinn-platform/commit/57862a55aabdf86eb5b0d899d422ac8445747425))
+
+## [0.4.1](https://github.com/Altinn/altinn-platform/compare/flux-oci-blackbox-exporter-v0.4.0...flux-oci-blackbox-exporter-v0.4.1) (2025-12-03)
+
+
+### Dependency Updates
+
+* update helm release prometheus-blackbox-exporter to v11.5.0 ([#2656](https://github.com/Altinn/altinn-platform/issues/2656)) ([88d6f86](https://github.com/Altinn/altinn-platform/commit/88d6f86a02a4959a4283a56b024d4a1e6ffedd52))
+
+## [0.4.0](https://github.com/Altinn/altinn-platform/compare/flux-oci-blackbox-exporter-v0.3.0...flux-oci-blackbox-exporter-v0.4.0) (2025-11-27)
+
+
+### Features
+
+* add flux artifact for blackbox exporter ([#2405](https://github.com/Altinn/altinn-platform/issues/2405)) ([88bd99c](https://github.com/Altinn/altinn-platform/commit/88bd99cb8991de33bc2468690576f5df215181ac))
+* Add Renovate Helmreleases detection and config ([#2493](https://github.com/Altinn/altinn-platform/issues/2493)) ([a873283](https://github.com/Altinn/altinn-platform/commit/a87328365fd08c2b050fa62757727461402726d2))
+
+
+### Bug Fixes
+
+* **blackbox-exporter:** update url to an existing url ([#2415](https://github.com/Altinn/altinn-platform/issues/2415)) ([cac97b8](https://github.com/Altinn/altinn-platform/commit/cac97b8247c7d8a6ffe890a351bd5c69ef062324))
+* flux blackbox exporter ns linkerd enable true ([#2431](https://github.com/Altinn/altinn-platform/issues/2431)) ([7b80f7f](https://github.com/Altinn/altinn-platform/commit/7b80f7fd50ca69dab877d054b35e17e4ce9bdfd6))

--- a/oci/blackbox-exporter/altinn-uptime/kustomization.yaml
+++ b/oci/blackbox-exporter/altinn-uptime/kustomization.yaml
@@ -1,0 +1,175 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base
+patches:
+  - target:
+      kind: HelmRelease
+      name: prometheus-blackbox-exporter
+    patch: |-
+      apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      metadata:
+        name: prometheus-blackbox-exporter
+      spec:
+        values:
+          replicas: 3
+          podDisruptionBudget:
+            enabled: true
+            minAvailable: 1
+          livenessProbe:
+            httpGet:
+              path: /-/healthy
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /-/healthy
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+          config:
+            modules:
+              http_2xx_ipv6:
+                prober: http
+                timeout: 10s
+                http:
+                  valid_http_versions: ["HTTP/1.1", "HTTP/2.0"]
+                  valid_status_codes: []
+                  method: GET
+                  follow_redirects: false
+                  fail_if_ssl: false
+                  fail_if_not_ssl: false
+                  preferred_ip_protocol: ip6
+                  ip_protocol_fallback: false
+              http_2xx_ipv4:
+                prober: http
+                timeout: 10s
+                http:
+                  valid_http_versions: ["HTTP/1.1", "HTTP/2.0"]
+                  valid_status_codes: []
+                  method: GET
+                  follow_redirects: false
+                  fail_if_ssl: false
+                  fail_if_not_ssl: false
+                  preferred_ip_protocol: ip4
+                  ip_protocol_fallback: false
+              tcp_connect_ipv4:
+                prober: tcp
+                timeout: 10s
+                tcp:
+                  preferred_ip_protocol: ip4
+                  ip_protocol_fallback: false
+              tcp_connect_ipv6:
+                prober: tcp
+                timeout: 10s
+                tcp:
+                  preferred_ip_protocol: ip6
+                  ip_protocol_fallback: false
+              icmp_ipv4:
+                prober: icmp
+                timeout: 10s
+                icmp:
+                  preferred_ip_protocol: ip4
+                  ip_protocol_fallback: false
+              icmp_ipv6:
+                prober: icmp
+                timeout: 10s
+                icmp:
+                  preferred_ip_protocol: ip6
+                  ip_protocol_fallback: false
+              http_2xx_ipv6_kuberneteswrapper:
+                prober: http
+                timeout: 10s
+                http:
+                  valid_http_versions: ["HTTP/1.1", "HTTP/2.0"]
+                  valid_status_codes: []
+                  method: GET
+                  follow_redirects: false
+                  fail_if_ssl: false
+                  fail_if_not_ssl: false
+                  preferred_ip_protocol: ip6
+                  ip_protocol_fallback: false
+                  fail_if_body_not_matches_regexp:
+                    - "kuberneteswrapper"
+              http_2xx_ipv4_kuberneteswrapper:
+                prober: http
+                timeout: 10s
+                http:
+                  valid_http_versions: ["HTTP/1.1", "HTTP/2.0"]
+                  valid_status_codes: []
+                  method: GET
+                  follow_redirects: false
+                  fail_if_ssl: false
+                  fail_if_not_ssl: false
+                  preferred_ip_protocol: ip4
+                  ip_protocol_fallback: false
+                  fail_if_body_not_matches_regexp:
+                    - "kuberneteswrapper"
+              http_alive_tls_ipv4:
+                prober: http
+                timeout: 10s
+                http:
+                  method: GET
+                  follow_redirects: false
+                  preferred_ip_protocol: ip4
+                  ip_protocol_fallback: false
+                  tls_config:
+                    insecure_skip_verify: false
+                  valid_status_codes:
+                    - 200
+                    - 201
+                    - 202
+                    - 203
+                    - 204
+                    - 205
+                    - 206
+                    - 300
+                    - 301
+                    - 302
+                    - 303
+                    - 304
+                    - 307
+                    - 308
+                    - 400
+                    - 401
+                    - 403
+                    - 404
+              http_alive_tls_ipv6:
+                prober: http
+                timeout: 10s
+                http:
+                  method: GET
+                  follow_redirects: false
+                  preferred_ip_protocol: ip6
+                  ip_protocol_fallback: false
+                  tls_config:
+                    insecure_skip_verify: false
+                  valid_status_codes:
+                    - 200
+                    - 201
+                    - 202
+                    - 203
+                    - 204
+                    - 205
+                    - 206
+                    - 300
+                    - 301
+                    - 302
+                    - 303
+                    - 304
+                    - 307
+                    - 308
+                    - 400
+                    - 401
+                    - 403
+                    - 404

--- a/oci/blackbox-exporter/apps/helmrelease-patch.yaml
+++ b/oci/blackbox-exporter/apps/helmrelease-patch.yaml
@@ -1,0 +1,18 @@
+- op: add
+  path: /spec/values/serviceMonitor/targets/-
+  value: 
+    name: ${PLATFORM_URL}
+    url: https://${PLATFORM_URL}/kuberneteswrapper/api/v1/deployments
+    hostname: ${PLATFORM_URL}
+    interval: 60s
+    scrapeTimeout: 30s
+    module: http_2xx
+- op: add
+  path: /spec/values/serviceMonitor/targets/-
+  value:
+    name: ${MASKINPORTEN_URL}
+    url: https://${MASKINPORTEN_URL}
+    hostname: ${MASKINPORTEN_URL}
+    interval: 60s
+    scrapeTimeout: 30s
+    module: http_2xx

--- a/oci/blackbox-exporter/apps/kustomization.yaml
+++ b/oci/blackbox-exporter/apps/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base
+patches:
+  - path: helmrelease-patch.yaml
+    target:
+      kind: HelmRelease
+      name: prometheus-blackbox-exporter

--- a/oci/blackbox-exporter/base/helmrelease.yaml
+++ b/oci/blackbox-exporter/base/helmrelease.yaml
@@ -1,0 +1,67 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: prometheus-blackbox-exporter
+  namespace: monitoring
+spec:
+  chart:
+    spec:
+      chart: prometheus-blackbox-exporter
+      sourceRef:
+        kind: HelmRepository
+        name: prometheus-community
+        namespace: monitoring
+      # renovate: datasource=helm registryUrl=https://prometheus-community.github.io/helm-charts packageName=prometheus-blackbox-exporter
+      version: 11.5.0
+  interval: 1h
+  timeout: 15m
+  install:
+    crds: CreateReplace
+    remediation:
+      retries: 5
+  upgrade:
+    crds: CreateReplace
+    remediation:
+      retries: 5
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              kind: ServiceMonitor
+              group: monitoring.coreos.com
+            patch: |-
+              - op: replace
+                path: /apiVersion
+                value: azmonitoring.coreos.com/v1
+              - op: add
+                path: /spec/labelLimit
+                value: 63
+              - op: add
+                path: /spec/labelNameLengthLimit
+                value: 511
+              - op: add
+                path: /spec/labelValueLengthLimit
+                value: 1023
+          - target:
+              kind: PodMonitor
+              group: monitoring.coreos.com
+            patch: |-
+              - op: replace
+                path: /apiVersion
+                value: azmonitoring.coreos.com/v1
+              - op: add
+                path: /spec/labelLimit
+                value: 63
+              - op: add
+                path: /spec/labelNameLengthLimit
+                value: 511
+              - op: add
+                path: /spec/labelValueLengthLimit
+                value: 1023
+  targetNamespace: monitoring
+  values:
+    image:
+      registry: altinncr.azurecr.io/quay.io
+    serviceMonitor:
+      enabled: true
+      targets: []

--- a/oci/blackbox-exporter/base/helmrepository.yaml
+++ b/oci/blackbox-exporter/base/helmrepository.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: prometheus-community
+  namespace: monitoring
+spec:
+  interval: 1h
+  url: https://prometheus-community.github.io/helm-charts

--- a/oci/blackbox-exporter/base/kustomization.yaml
+++ b/oci/blackbox-exporter/base/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - helmrepository.yaml
+  - helmrelease.yaml

--- a/oci/blackbox-exporter/base/namespace.yaml
+++ b/oci/blackbox-exporter/base/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: monitoring
+  annotations:
+    linkerd.io/inject: enabled

--- a/oci/releaseconfig.json
+++ b/oci/releaseconfig.json
@@ -22,5 +22,13 @@
     "tt_ring2": "1.4.0",
     "prod_ring1": "1.4.0",
     "prod_ring2": "1.4.0"
+  },
+  "blackbox-exporter": {
+    "at_ring1": "0.5.1",
+    "at_ring2": "0.5.1",
+    "tt_ring1": "0.5.1",
+    "tt_ring2": "0.5.1",
+    "prod_ring1": "0.5.1",
+    "prod_ring2": "0.5.1"
   }
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -11,6 +11,10 @@
     "oci/whoami": {
       "release-type": "simple",
       "component": "oci-whoami"
+    },
+    "oci/blackbox-exporter": {
+      "release-type": "simple",
+      "component": "flux-oci-blackbox-exporter"
     }
   },
   "separate-pull-requests": true,


### PR DESCRIPTION
Include prometheus-blackbox-exporter HelmRelease, HelmRepository, kustomizations, ServiceMonitor patches, app patches and changelog, and bump release configs/manifest to v0.5.1.