### PR TITLE
feat!: Inject Linkerd and add Traefik header middleware

### DIFF
--- a/oci/whoami/namespace.yaml
+++ b/oci/whoami/namespace.yaml
@@ -2,3 +2,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: whoami
+  annotations:
+    linkerd.io/inject: enabled

--- a/oci/whoami/whoami.yaml
+++ b/oci/whoami/whoami.yaml
@@ -54,6 +54,16 @@ spec:
     app: whoami
 ---
 apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: l5d-header-middleware
+  namespace: whoami
+spec:
+  headers:
+    customRequestHeaders:
+      l5d-dst-override: whoami.whoami.svc.cluster.local:80
+---
+apiVersion: traefik.io/v1alpha1
 kind: IngressRoute
 metadata:
   name: whoami
@@ -65,6 +75,9 @@ spec:
   routes:
     - kind: Rule
       match: HostRegexp(`^.*\.?altinn\.(no|cloud)$`) && (PathPrefix(`/whoami/`) || Path(`/whoami`))
+      middlewares:
+        - name: l5d-header-middleware
+          namespace: whoami
       services:
         - name: whoami
           namespace: whoami


### PR DESCRIPTION
Enable Linkerd sidecar injection via namespace annotation. Add Traefik Middleware (l5d-header-middleware) that sets the l5d-dst-override header and attach it to the whoami IngressRoute.