### PR TITLE
feat: Add TLS certs and PushSecrets for af hosts

### DIFF
--- a/oci/dis-tls-cert/certs/af.at23.altinn.cloud-push.yaml
+++ b/oci/dis-tls-cert/certs/af.at23.altinn.cloud-push.yaml
@@ -1,0 +1,35 @@
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  name: af-at23-altinn-cloud-push
+  namespace: dis-tls-cert
+spec:
+  refreshInterval: 1h
+  secretStoreRefs:
+    - name: dis-tls-cert-store
+      kind: SecretStore
+  selector:
+    secret:
+      name: af-at23-altinn-cloud
+  template:
+    engineVersion: v2
+    type: kubernetes.io/tls
+    data:
+      tls.crt: '{{ index . "tls.crt" }}'
+      tls.key: '{{ index . "tls.key" }}'
+      pfx_bundle: '{{ fullPemToPkcs12 (index . "tls.crt") (index . "tls.key") | b64dec }}'
+  data:
+    # PEM format for Kubernetes clusters
+    - match:
+        secretKey: tls.crt
+        remoteRef:
+          remoteKey: af-at23-altinn-cloud-crt
+    - match:
+        secretKey: tls.key
+        remoteRef:
+          remoteKey: af-at23-altinn-cloud-key
+    # PFX format for Azure services
+    - match:
+        secretKey: pfx_bundle
+        remoteRef:
+          remoteKey: cert/af-at23-altinn-cloud

--- a/oci/dis-tls-cert/certs/af.at23.altinn.cloud.yaml
+++ b/oci/dis-tls-cert/certs/af.at23.altinn.cloud.yaml
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: af-at23-altinn-cloud
+  namespace: dis-tls-cert
+spec:
+  secretName: af-at23-altinn-cloud
+  issuerRef:
+    name: zerossl-dis-tls-cert
+    kind: ClusterIssuer
+  dnsNames:
+    - af.at23.altinn.cloud

--- a/oci/dis-tls-cert/certs/af.yt01.altinn.cloud-push.yaml
+++ b/oci/dis-tls-cert/certs/af.yt01.altinn.cloud-push.yaml
@@ -1,0 +1,35 @@
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  name: af-yt01-altinn-cloud-push
+  namespace: dis-tls-cert
+spec:
+  refreshInterval: 1h
+  secretStoreRefs:
+    - name: dis-tls-cert-store
+      kind: SecretStore
+  selector:
+    secret:
+      name: af-yt01-altinn-cloud
+  template:
+    engineVersion: v2
+    type: kubernetes.io/tls
+    data:
+      tls.crt: '{{ index . "tls.crt" }}'
+      tls.key: '{{ index . "tls.key" }}'
+      pfx_bundle: '{{ fullPemToPkcs12 (index . "tls.crt") (index . "tls.key") | b64dec }}'
+  data:
+    # PEM format for Kubernetes clusters
+    - match:
+        secretKey: tls.crt
+        remoteRef:
+          remoteKey: af-yt01-altinn-cloud-crt
+    - match:
+        secretKey: tls.key
+        remoteRef:
+          remoteKey: af-yt01-altinn-cloud-key
+    # PFX format for Azure services
+    - match:
+        secretKey: pfx_bundle
+        remoteRef:
+          remoteKey: cert/af-yt01-altinn-cloud

--- a/oci/dis-tls-cert/certs/af.yt01.altinn.cloud.yaml
+++ b/oci/dis-tls-cert/certs/af.yt01.altinn.cloud.yaml
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: af-yt01-altinn-cloud
+  namespace: dis-tls-cert
+spec:
+  secretName: af-yt01-altinn-cloud
+  issuerRef:
+    name: zerossl-dis-tls-cert
+    kind: ClusterIssuer
+  dnsNames:
+    - af.yt01.altinn.cloud

--- a/oci/dis-tls-cert/certs/kustomization.yaml
+++ b/oci/dis-tls-cert/certs/kustomization.yaml
@@ -1,5 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - af.yt01.altinn.cloud.yaml
+  - af.yt01.altinn.cloud-push.yaml
+  - af.at23.altinn.cloud.yaml
+  - af.at23.altinn.cloud-push.yaml
   - af.tt02.altinn.no.yaml
   - af.tt02.altinn.no-push.yaml


### PR DESCRIPTION
Add cert-manager Certificate and external-secrets PushSecret manifests for af.yt01.altinn.cloud and af.at23.altinn.cloud, and update kustomization to include the new files