### PR TITLE
feat: Add oci/platform-system release and config

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -5,5 +5,6 @@
   "oci/dis-tls-cert": "2.7.0",
   "oci/grafana-operator": "2.0.0",
   "oci/linkerd": "1.9.0",
+  "oci/platform-system": "1.0.0",
   "oci/whoami": "0.5.0"
 }

--- a/oci/platform-system/kustomization.yaml
+++ b/oci/platform-system/kustomization.yaml
@@ -3,4 +3,3 @@ kind: Kustomization
 resources:
   - namespace.yaml
   - clusterrolebinding.yaml
-  - platform-admin-access.yaml

--- a/oci/releaseconfig.json
+++ b/oci/releaseconfig.json
@@ -47,6 +47,14 @@
     "prod_ring1": "1.9.0",
     "prod_ring2": "1.7.0"
   },
+  "platform-system": {
+    "at_ring1": "1.0.0",
+    "at_ring2": "1.0.0",
+    "tt_ring1": "1.0.0",
+    "tt_ring2": "1.0.0",
+    "prod_ring1": "1.0.0",
+    "prod_ring2": "1.0.0"
+  },
   "whoami": {
     "at_ring1": "0.5.0",
     "at_ring2": "0.5.0",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -24,6 +24,10 @@
       "release-type": "simple",
       "component": "oci-linkerd"
     },
+    "oci/platform-system": {
+      "release-type": "simple",
+      "component": "oci-platform-system"
+    },
     "oci/whoami": {
       "release-type": "simple",
       "component": "oci-whoami"


### PR DESCRIPTION
Add manifest entry and release-please config for oci/platform-system. Add releaseconfig entries setting all rings to 1.0.0. Remove platform-admin-access from the platform-system kustomization.