### PR TITLE
chore: move certm-lets-encrypt-dns-issuer to dis way

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -3,6 +3,7 @@
   "oci/azure-service-operator": "1.2.0",
   "oci/blackbox-exporter": "0.7.0",
   "oci/cert-manager": "2.0.0",
+  "oci/certm-lets-encrypt-dns-issuer": "0.3.0",
   "oci/dis-tls-cert": "2.7.0",
   "oci/external-secrets-operator": "1.2.0",
   "oci/grafana-operator": "2.0.0",

--- a/oci/certm-lets-encrypt-dns-issuer/CHANGELOG.md
+++ b/oci/certm-lets-encrypt-dns-issuer/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## [0.3.0](https://github.com/Altinn/altinn-platform/compare/flux-oci-certm-lets-encrypt-dns-issuer-v0.2.0...flux-oci-certm-lets-encrypt-dns-issuer-v0.3.0) (2025-12-02)
+
+
+### Features
+
+* **dis-cr:** deploy certificate that uses letsencrypt-staging cluster-issuer ([#2136](https://github.com/Altinn/altinn-platform/issues/2136)) ([2e8fc90](https://github.com/Altinn/altinn-platform/commit/2e8fc90bd191c8ddf2fbf69bdb81c6612d58d21d))
+* **dis-cr:** deploy dns child zone and cert-manager tls issuer ([#2126](https://github.com/Altinn/altinn-platform/issues/2126)) ([c9d50fe](https://github.com/Altinn/altinn-platform/commit/c9d50fe99658ec5ad8e2aacceb5db652ff38af9d))

--- a/oci/certm-lets-encrypt-dns-issuer/certificate.yaml
+++ b/oci/certm-lets-encrypt-dns-issuer/certificate.yaml
@@ -1,0 +1,13 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: wildcard-tls
+  namespace: traefik
+spec:
+  secretName: ssl-cert
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+    - "${AZURE_DNS_ZONE_NAME}"
+    - "*.${AZURE_DNS_ZONE_NAME}"

--- a/oci/certm-lets-encrypt-dns-issuer/kustomization.yaml
+++ b/oci/certm-lets-encrypt-dns-issuer/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - staging.yaml
+  - production.yaml
+  - certificate.yaml

--- a/oci/certm-lets-encrypt-dns-issuer/production.yaml
+++ b/oci/certm-lets-encrypt-dns-issuer/production.yaml
@@ -1,0 +1,18 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-production
+spec:
+  acme:
+    server: "https://acme-v02.api.letsencrypt.org/directory"
+    privateKeySecretRef:
+      name: letsencrypt-production
+    solvers:
+    - dns01:
+        azureDNS:
+          hostedZoneName: ${AZURE_DNS_ZONE_NAME}
+          resourceGroupName: ${AZURE_RESOURCE_GROUP}
+          subscriptionID: ${AZURE_SUBSCRIPTION_ID}
+          environment: AzurePublicCloud
+          managedIdentity:
+            clientID: ${IDENTITY_CLIENT_ID}

--- a/oci/certm-lets-encrypt-dns-issuer/staging.yaml
+++ b/oci/certm-lets-encrypt-dns-issuer/staging.yaml
@@ -1,0 +1,18 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-staging
+spec:
+  acme:
+    server: "https://acme-staging-v02.api.letsencrypt.org/directory"
+    privateKeySecretRef:
+      name: letsencrypt-staging
+    solvers:
+    - dns01:
+        azureDNS:
+          hostedZoneName: ${AZURE_DNS_ZONE_NAME}
+          resourceGroupName: ${AZURE_RESOURCE_GROUP}
+          subscriptionID: ${AZURE_SUBSCRIPTION_ID}
+          environment: AzurePublicCloud
+          managedIdentity:
+            clientID: ${IDENTITY_CLIENT_ID}

--- a/oci/releaseconfig.json
+++ b/oci/releaseconfig.json
@@ -31,6 +31,14 @@
     "prod_ring1": "2.0.0",
     "prod_ring2": "1.5.0"
   },
+  "certm-lets-encrypt-dns-issuer": {
+    "at_ring1": "0.3.0",
+    "at_ring2": "0.3.0",
+    "tt_ring1": "0.3.0",
+    "tt_ring2": "0.3.0",
+    "prod_ring1": "0.3.0",
+    "prod_ring2": "0.3.0"
+  },
   "dis-tls-cert": {
     "at_ring1": "2.7.0",
     "at_ring2": "2.7.0",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -16,6 +16,10 @@
       "release-type": "simple",
       "component": "oci-cert-manager"
     },
+    "oci/certm-lets-encrypt-dns-issuer": {
+      "release-type": "simple",
+      "component": "oci-certm-lets-encrypt-dns-issuer"
+    },
     "oci/dis-tls-cert": {
       "release-type": "simple",
       "component": "oci-dis-tls-cert"


### PR DESCRIPTION
Moved from https://github.com/Altinn/altinn-platform/pull/3048