### PR TITLE
feat(kyverno-policies): add HelmRelease values

### DIFF
--- a/oci/kyverno-policies/apps/kustomization.yaml
+++ b/oci/kyverno-policies/apps/kustomization.yaml
@@ -2,3 +2,31 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../base
+patches:
+  - target:
+      kind: HelmRelease
+    patch: |
+      - op: add
+        path: /spec/values
+        value:
+          podSecurityStandard: baseline
+          podSecuritySeverity: medium
+          validationFailureAction: Audit
+          background: true
+          policyExclude:
+            all:
+              any:
+                - resources:
+                    namespaces:
+                      - cert-manager
+                      - external-secrets
+                      - flux-system
+                      - grafana
+                      - kube-node-lease
+                      - kube-public
+                      - kube-system
+                      - kyverno
+                      - linkerd
+                      - monitoring
+                      - platform-system
+                      - traefik

--- a/oci/kyverno-policies/multitenancy/kustomization.yaml
+++ b/oci/kyverno-policies/multitenancy/kustomization.yaml
@@ -21,3 +21,27 @@ patches:
       - op: add
         path: /spec/targetNamespace
         value: kyverno
+      - op: add
+        path: /spec/values
+        value:
+          podSecurityStandard: baseline
+          podSecuritySeverity: medium
+          validationFailureAction: Audit
+          background: true
+          policyExclude:
+            all:
+              any:
+                - resources:
+                    namespaces:
+                      - cert-manager
+                      - external-secrets
+                      - flux-system
+                      - grafana
+                      - kube-node-lease
+                      - kube-public
+                      - kube-system
+                      - kyverno
+                      - linkerd
+                      - monitoring
+                      - platform-system
+                      - traefik


### PR DESCRIPTION
Add /spec/values to Kyverno HelmRelease in apps and multitenancy kustomizations. Values set podSecurityStandard=baseline, podSecuritySeverity=medium, validationFailureAction=Audit, background=true, and a policyExclude for common system/platform namespaces (cert-manager, external-secrets, flux-system, grafana, kube-node-lease, kube-public, kube-system, kyverno, linkerd, monitoring, platform-system, traefik)