### PR TITLE
feat(linkerd): Add node CIDR auth and admin svcs

### DIFF
--- a/oci/linkerd/README.md
+++ b/oci/linkerd/README.md
@@ -10,8 +10,8 @@ Linkerd service mesh with High Availability configuration.
 | `DISABLE_IPV6` | `false` | No | Disable IPv6 support in the proxy |
 | `AKS_POD_IPV4_CIDR` | `10.240.0.0/16` | No | Pod network IPv4 CIDR (policies only) |
 | `AKS_POD_IPV6_CIDR` | `fd10:59f0:8c79:240::/64` | No | Pod network IPv6 CIDR (policies only) |
-| `AKS_NODE_IPV4_CIDR` | - | Yes | Node network IPv4 CIDR (policies only) |
-| `AKS_NODE_IPV6_CIDR` | - | Yes | Node network IPv6 CIDR (policies only) |
+| `AKS_VNET_IPV4_CIDR` | - | Yes | AKS VNET IPv4 CIDR (policies only) |
+| `AKS_VNET_IPV6_CIDR` | - | Yes | AKS VNET IPv6 CIDR (policies only) |
 
 ## Usage
 
@@ -24,6 +24,6 @@ spec:
     substitute:
       DEFAULT_INBOUND_POLICY: "cluster-authenticated"
       DISABLE_IPV6: "true"
-      AKS_NODE_IPV4_CIDR: "10.205.0.0/16"
-      AKS_NODE_IPV6_CIDR: "fd12:2291:d70a::/56"
+      AKS_VNET_IPV4_CIDR: "10.205.0.0/16"
+      AKS_VNET_IPV6_CIDR: "fd12:2291:d70a::/56"
 ```

--- a/oci/linkerd/policies/README.md
+++ b/oci/linkerd/policies/README.md
@@ -90,8 +90,8 @@ Without these policies, the following will fail when using restrictive inbound p
 |----------|---------|----------|-------------|
 | `AKS_POD_IPV4_CIDR` | `10.240.0.0/16` | No | Pod network IPv4 CIDR |
 | `AKS_POD_IPV6_CIDR` | `fd10:59f0:8c79:240::/64` | No | Pod network IPv6 CIDR |
-| `AKS_NODE_IPV4_CIDR` | - | Yes | Node network IPv4 CIDR |
-| `AKS_NODE_IPV6_CIDR` | - | Yes | Node network IPv6 CIDR |
+| `AKS_VNET_IPV4_CIDR` | - | Yes | AKS VNET IPv4 CIDR (for API server and kubelet) |
+| `AKS_VNET_IPV6_CIDR` | - | Yes | AKS VNET IPv6 CIDR (for API server and kubelet) |
 
 ## Usage
 
@@ -102,8 +102,6 @@ spec:
   path: ./policies
   postBuild:
     substitute:
-      AKS_POD_IPV4_CIDR: "10.240.0.0/16"
-      AKS_POD_IPV6_CIDR: "fd10:59f0:8c79:240::/64"
-      AKS_NODE_IPV4_CIDR: "10.205.0.0/16"
-      AKS_NODE_IPV6_CIDR: "fd12:2291:d70a::/56"
+      AKS_VNET_IPV4_CIDR: "10.205.0.0/16"
+      AKS_VNET_IPV6_CIDR: "fd12:2291:d70a::/56"
 ```

--- a/oci/linkerd/policies/core-linkerd-control-plane-policies.yaml
+++ b/oci/linkerd/policies/core-linkerd-control-plane-policies.yaml
@@ -82,7 +82,7 @@ spec:
       kind: NetworkAuthentication
       name: kube-api-server
 ---
-# Network auth for API server (includes node CIDR for AKS API Server VNET Integration)
+# Network auth for API server (includes VNET CIDR for AKS API Server VNET Integration)
 apiVersion: policy.linkerd.io/v1alpha1
 kind: NetworkAuthentication
 metadata:
@@ -92,8 +92,8 @@ spec:
   networks:
     - cidr: ${AKS_POD_IPV4_CIDR:=10.240.0.0/16}
     - cidr: ${AKS_POD_IPV6_CIDR:=fd10:59f0:8c79:240::/64}
-    - cidr: ${AKS_NODE_IPV4_CIDR}
-    - cidr: ${AKS_NODE_IPV6_CIDR}
+    - cidr: ${AKS_VNET_IPV4_CIDR}
+    - cidr: ${AKS_VNET_IPV6_CIDR}
 ---
 # Network auth for kubelet health checks
 apiVersion: policy.linkerd.io/v1alpha1
@@ -103,8 +103,8 @@ metadata:
   namespace: linkerd
 spec:
   networks:
-    - cidr: ${AKS_NODE_IPV4_CIDR}
-    - cidr: ${AKS_NODE_IPV6_CIDR}
+    - cidr: ${AKS_VNET_IPV4_CIDR}
+    - cidr: ${AKS_VNET_IPV6_CIDR}
 ---
 # Health check servers for destination pods
 apiVersion: policy.linkerd.io/v1beta3


### PR DESCRIPTION
Introduce AKS_NODE_IPV4_CIDR/AKS_NODE_IPV6_CIDR and update READMEs/examples.
Include node CIDRs in kube-api-server NetworkAuthentication and add a kubelet NetworkAuthentication. Add health-check Server resources and AuthorizationPolicies for control plane components, plus MeshTLSAuthentication
and gRPC Servers/AuthorizationPolicies for identity/destination/policy. Also
adjust webhook selectors and ports to use destination component and named ports