### PR TITLE
fix(otel-collector): set proxyProtocol to unknown for OTLP HTTP port

### DIFF
--- a/oci/otel-collector/policies/ingress-policy.yaml
+++ b/oci/otel-collector/policies/ingress-policy.yaml
@@ -21,7 +21,7 @@ spec:
     matchLabels:
       app.kubernetes.io/name: otel-collector
   port: 4318
-  proxyProtocol: HTTP
+  proxyProtocol: unknown
 ---
 apiVersion: policy.linkerd.io/v1alpha1
 kind: MeshTLSAuthentication


### PR DESCRIPTION
Changes the Linkerd Server proxyProtocol for the OTLP HTTP port (4318) from 'HTTP' to 'unknown'. This prevents Linkerd from enforcing specific HTTP versions (HTTP/1 vs HTTP/2), ensuring compatibility with clients that may use either version.