### PR TITLE
feat: add Linkerd policies for external-secrets

### DIFF
--- a/oci/external-secrets-operator/policies/external-secrets-policy.yaml
+++ b/oci/external-secrets-operator/policies/external-secrets-policy.yaml
@@ -11,6 +11,30 @@ spec:
   port: 10250
   proxyProtocol: TLS
 ---
+apiVersion: policy.linkerd.io/v1beta3
+kind: Server
+metadata:
+  name: external-secrets-webhook-health
+  namespace: external-secrets
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: external-secrets-webhook
+  port: ready
+  proxyProtocol: HTTP/1
+---
+apiVersion: policy.linkerd.io/v1beta3
+kind: Server
+metadata:
+  name: external-secrets-cert-controller-health
+  namespace: external-secrets
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: external-secrets-cert-controller
+  port: ready
+  proxyProtocol: HTTP/1
+---
 apiVersion: policy.linkerd.io/v1alpha1
 kind: AuthorizationPolicy
 metadata:
@@ -27,6 +51,36 @@ spec:
       name: kube-api-server
 ---
 apiVersion: policy.linkerd.io/v1alpha1
+kind: AuthorizationPolicy
+metadata:
+  name: external-secrets-webhook-health
+  namespace: external-secrets
+spec:
+  targetRef:
+    group: policy.linkerd.io
+    kind: Server
+    name: external-secrets-webhook-health
+  requiredAuthenticationRefs:
+    - group: policy.linkerd.io
+      kind: NetworkAuthentication
+      name: kubelet
+---
+apiVersion: policy.linkerd.io/v1alpha1
+kind: AuthorizationPolicy
+metadata:
+  name: external-secrets-cert-controller-health
+  namespace: external-secrets
+spec:
+  targetRef:
+    group: policy.linkerd.io
+    kind: Server
+    name: external-secrets-cert-controller-health
+  requiredAuthenticationRefs:
+    - group: policy.linkerd.io
+      kind: NetworkAuthentication
+      name: kubelet
+---
+apiVersion: policy.linkerd.io/v1alpha1
 kind: NetworkAuthentication
 metadata:
   name: kube-api-server
@@ -35,3 +89,15 @@ spec:
   networks:
     - cidr: ${AKS_POD_IPV4_CIDR:=10.240.0.0/16}
     - cidr: ${AKS_POD_IPV6_CIDR:=fd10:59f0:8c79:240::/64}
+    - cidr: ${AKS_VNET_IPV4_CIDR}
+    - cidr: ${AKS_VNET_IPV6_CIDR}
+---
+apiVersion: policy.linkerd.io/v1alpha1
+kind: NetworkAuthentication
+metadata:
+  name: kubelet
+  namespace: external-secrets
+spec:
+  networks:
+    - cidr: ${AKS_VNET_IPV4_CIDR}
+    - cidr: ${AKS_VNET_IPV6_CIDR}


### PR DESCRIPTION
Add Linkerd Server and AuthorizationPolicy for the webhook and cert-controller health endpoints. Also add NetworkAuthentication entries including kubelet and VNET CIDRs populated from AKS_VNET_IPV4_CIDR and AKS_VNET_IPV6_CIDR variables.