### PR TITLE
fix: Use NetworkAuthentication for control plane

### DIFF
--- a/oci/linkerd/policies/README.md
+++ b/oci/linkerd/policies/README.md
@@ -74,11 +74,11 @@ When using a restrictive `DEFAULT_INBOUND_POLICY` (like `cluster-authenticated` 
 
 | Server | Component | Port | Auth | Purpose |
 |--------|-----------|------|------|---------|
-| `identity-grpc` | identity | ident-grpc | NetworkAuth | Proxies obtain TLS certificates (bootstrap) |
-| `destination-grpc` | destination | dest-grpc | MeshTLS | Proxies get service discovery info |
-| `policy-grpc` | destination | policy-grpc | MeshTLS | Proxies get policy updates |
+| `identity-grpc` | identity | ident-grpc | NetworkAuth | Proxies obtain TLS certificates |
+| `destination-grpc` | destination | dest-grpc | NetworkAuth | Proxies get service discovery info |
+| `policy-grpc` | destination | policy-grpc | NetworkAuth | Proxies get policy updates |
 
-Note: `identity-grpc` uses `NetworkAuthentication` instead of `MeshTLSAuthentication` because bootstrapping proxies don't have mTLS identity yet (chicken-and-egg problem).
+Note: All control plane gRPC services use `NetworkAuthentication` (pod CIDRs) instead of `MeshTLSAuthentication` because bootstrapping proxies need to access these services before they have mTLS identity (chicken-and-egg problem).
 
 ## Why This Matters
 

--- a/oci/linkerd/policies/core-linkerd-control-plane-policies.yaml
+++ b/oci/linkerd/policies/core-linkerd-control-plane-policies.yaml
@@ -296,7 +296,8 @@ spec:
       kind: NetworkAuthentication
       name: cluster-pods
 ---
-# Destination gRPC - proxies need this for service discovery and policy
+# Destination gRPC - proxies need this for service discovery
+# NOTE: Uses NetworkAuthentication because bootstrapping proxies need this before having mTLS
 apiVersion: policy.linkerd.io/v1beta3
 kind: Server
 metadata:
@@ -321,10 +322,11 @@ spec:
     name: destination-grpc
   requiredAuthenticationRefs:
     - group: policy.linkerd.io
-      kind: MeshTLSAuthentication
-      name: any-meshed-pod
+      kind: NetworkAuthentication
+      name: cluster-pods
 ---
 # Policy gRPC - proxies need this for policy updates
+# NOTE: Uses NetworkAuthentication because bootstrapping proxies need this before having mTLS
 apiVersion: policy.linkerd.io/v1beta3
 kind: Server
 metadata:
@@ -349,5 +351,5 @@ spec:
     name: policy-grpc
   requiredAuthenticationRefs:
     - group: policy.linkerd.io
-      kind: MeshTLSAuthentication
-      name: any-meshed-pod
+      kind: NetworkAuthentication
+      name: cluster-pods


### PR DESCRIPTION
Update Linkerd control-plane Server resources to require NetworkAuthentication
(cluster-pods) for identity, destination, and policy gRPC. Clarify README to
explain bootstrapping proxies need pod-CIDR access before mTLS (chicken-and-egg).