### PR TITLE
fix(traefik): reduce metrics push interval from 10s to 60s

### DIFF
--- a/oci/traefik/base/helmrelease.yaml
+++ b/oci/traefik/base/helmrelease.yaml
@@ -162,6 +162,7 @@ spec:
       prometheus: null
       otlp:
         enabled: true
+        pushInterval: 60s
         grpc:
           enabled: true
           endpoint: "${OTEL_ENDPOINT:=otel-collector.monitoring.svc.cluster.local:4317}"


### PR DESCRIPTION
Ref: https://doc.traefik.io/traefik/reference/install-configuration/observability/metrics/#opt-metrics-otlp-pushInterval