### PR TITLE
feat: Add datakeys StorageClass and PVC

### DIFF
--- a/oci/container-runtime-aks-config/apps/kustomization.yaml
+++ b/oci/container-runtime-aks-config/apps/kustomization.yaml
@@ -4,4 +4,5 @@ resources:
   - ../base/ama-metrics-prometheus-config
   - ../base/ama-metrics-settings-configmap
   - ../base/container-azm-ms-agentconfig
+  - ../base/datakeys-storage-class
   - ../base/metrics-server-config

--- a/oci/container-runtime-aks-config/base/datakeys-storage-class/datakeys-pvc.yaml
+++ b/oci/container-runtime-aks-config/base/datakeys-storage-class/datakeys-pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: keys
+  namespace: default
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: datakeys

--- a/oci/container-runtime-aks-config/base/datakeys-storage-class/datakeys-storage-class.yaml
+++ b/oci/container-runtime-aks-config/base/datakeys-storage-class/datakeys-storage-class.yaml
@@ -1,0 +1,17 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: datakeys
+provisioner: file.csi.azure.com
+reclaimPolicy: Retain
+parameters:
+  skuName: Standard_ZRS
+mountOptions:
+  - file_mode=0777
+  - dir_mode=0777
+  - mfsymlinks
+  - uid=3000
+  - gid=2000
+  - nobrl
+  - cache=none
+  - nosharesock

--- a/oci/container-runtime-aks-config/base/datakeys-storage-class/kustomization.yaml
+++ b/oci/container-runtime-aks-config/base/datakeys-storage-class/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - datakeys-storage-class.yaml
+  - datakeys-pvc.yaml


### PR DESCRIPTION
Add StorageClass 'datakeys' (Azure File CSI) and a ReadWriteMany PVC named 'keys' in the default namespace. Register the new base in the apps kustomization so the resources are deployed.
Replace terraform config:
https://dev.azure.com/brreg/altinn-apps-ops/_git/terraform-modules?path=/modules/aks-apps-resources/datakeys-storage.tf