### PR TITLE
fix: add scrapeInterval to podMonitor configuration

### DIFF
--- a/oci/linkerd/base/helmrelease.yaml
+++ b/oci/linkerd/base/helmrelease.yaml
@@ -98,4 +98,5 @@ spec:
       defaultInboundPolicy: "${DEFAULT_INBOUND_POLICY:=all-unauthenticated}"
     podMonitor:
       enabled: true
+      scrapeInterval: 60s
     disableIPv6: "${DISABLE_IPV6:=false}"


### PR DESCRIPTION
Add scrapeInterval to podMonitor configuration and set interval to 60s instead of the default 10s