### PR TITLE
fix(oci/traefik): unquote DEFAULT_GATEWAY_HOSTNAME

### DIFF
--- a/oci/traefik/multitenancy/kustomization.yaml
+++ b/oci/traefik/multitenancy/kustomization.yaml
@@ -55,10 +55,24 @@ patches:
               hostname: ${DEFAULT_GATEWAY_HOSTNAME}
               namespacePolicy:
                 from: All
+            http-wildcard:
+              port: 8000
+              protocol: HTTP
+              hostname: "*.${DEFAULT_GATEWAY_HOSTNAME}"
+              namespacePolicy:
+                from: All
             https:
               port: 8443
               protocol: HTTPS
               hostname: ${DEFAULT_GATEWAY_HOSTNAME}
+              namespacePolicy:
+                from: All
+              certificateRefs:
+                - name: ssl-cert
+            https-wildcard:
+              port: 8443
+              protocol: HTTPS
+              hostname: "*.${DEFAULT_GATEWAY_HOSTNAME}"
               namespacePolicy:
                 from: All
               certificateRefs:


### PR DESCRIPTION
This is a Flux `postBuild.substitute` issue where the closing brace isn't being consumed by the substitution because the variable is inside double quotes in a YAML block scalar.