### PR TITLE
fix: add safe-to-evict to pods to signal autoscaler can evict pods

### DIFF
--- a/oci/blackbox-exporter/base/helmrelease.yaml
+++ b/oci/blackbox-exporter/base/helmrelease.yaml
@@ -65,3 +65,5 @@ spec:
     serviceMonitor:
       enabled: true
       targets: []
+    podAnnotations:
+      cluster-autoscaler.kubernetes.io/safe-to-evict:"true"

--- a/oci/external-secrets-operator/base/helmrelease.yaml
+++ b/oci/external-secrets-operator/base/helmrelease.yaml
@@ -37,3 +37,5 @@ spec:
     # actual auth is delegated via SecretStore.serviceAccountRef
     serviceAccount:
       create: false
+    podAnnotations:
+      cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/oci/otel-collector/base/collector.yaml
+++ b/oci/otel-collector/base/collector.yaml
@@ -14,6 +14,7 @@ spec:
           key: connectionString
   image: altinncr.azurecr.io/ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.140.1
   podAnnotations:
+    cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
     linkerd.io/inject: "enabled"
     config.linkerd.io/skip-outbound-ports: "443"
   resources:

--- a/oci/otel-operator/base/helmrelease.yaml
+++ b/oci/otel-operator/base/helmrelease.yaml
@@ -36,3 +36,5 @@ spec:
         config.linkerd.io/skip-outbound-ports: "443"
     admissionWebhooks:
       create: false
+    podAnnotations:
+      cluster-autoscaler.kubernetes.io/safe-to-evict: "true"


### PR DESCRIPTION
Studio identified som pods that didn't have the safe-to-evict annotation even though they had emptyDIr (linkerd).
Add the safe-to-evict annotation to signal that the autoscaler can evict these pods even though they have emptyDIr