### PR TITLE
feat(traefik): Include AKS pod CIDRs in policies

### DIFF
--- a/oci/traefik/README.md
+++ b/oci/traefik/README.md
@@ -85,16 +85,17 @@ The configuration relies on Flux post-build variable substitution. Required vari
 | `AKS_WORKPOOL_IP_PREFIX_1` | AKS Worker Pool IP Prefix |
 
 ### Multitenancy (`multitenancy`) Specific
-| Variable | Description |
-|----------|-------------|
-| `AKS_VNET_IPV4_CIDR` | Full AKS VNet IPv4 CIDR |
-| `AKS_VNET_IPV6_CIDR` | Full AKS VNet IPv6 CIDR |
-| `DEFAULT_GATEWAY_HOSTNAME`| Hostname for the default Gateway listener |
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `AKS_VNET_IPV4_CIDR` | Full AKS VNet IPv4 CIDR | - |
+| `AKS_VNET_IPV6_CIDR` | Full AKS VNet IPv6 CIDR | - |
+| `DEFAULT_GATEWAY_HOSTNAME`| Hostname for the default Gateway listener | - |
+| `AKS_POD_IPV4_CIDR` | AKS pod network IPv4 CIDR (overlay networking) | `10.240.0.0/16` |
+| `AKS_POD_IPV6_CIDR` | AKS pod network IPv6 CIDR (overlay networking) | `fd10:59f0:8c79:240::/64` |
 
 ## Policies (Multitenancy)
 The `policies/` directory contains Linkerd `Server`, `NetworkAuthentication`, and `AuthorizationPolicy` resources. These are critical for the multitenancy setup to allow:
--   Kubelet health probes (liveness/readiness).
--   Proxy admin access (localhost).
--   Prometheus scraping (if not using OTLP exclusively for this path).
+-   Kubelet health probes (liveness/readiness) from both pod and VNET CIDRs.
+-   Linkerd proxy admin health checks on port 4191.
 
-These policies ensure Traefik remains operational even when the cluster enforces a default "deny-all" inbound policy.
+These policies ensure Traefik remains operational even when the cluster enforces a default "deny-all" inbound policy. See [`policies/README.md`](policies/README.md) for details.

--- a/oci/traefik/policies/README.md
+++ b/oci/traefik/policies/README.md
@@ -14,7 +14,7 @@ When using a restrictive `DEFAULT_INBOUND_POLICY` (like `cluster-authenticated` 
 ```
 ┌─────────────────────┐
 │       kubelet       │
-│    (VNET CIDRs)     │
+│ (Pod + VNET CIDRs)  │
 └──────────┬──────────┘
            │
            ▼
@@ -42,7 +42,7 @@ When using a restrictive `DEFAULT_INBOUND_POLICY` (like `cluster-authenticated` 
 
 | Resource | Type | Purpose |
 |----------|------|---------|
-| `kubelet` | NetworkAuthentication | Allows traffic from VNET CIDRs (for health probes) |
+| `kubelet` | NetworkAuthentication | Allows traffic from pod and VNET CIDRs (for health probes) |
 
 ### Health Check Servers
 
@@ -69,5 +69,7 @@ Without these policies, the following will fail when using restrictive inbound p
 
 | Variable | Default | Required | Description |
 |----------|---------|----------|-------------|
+| `AKS_POD_IPV4_CIDR` | `10.240.0.0/16` | No | AKS pod network IPv4 CIDR (overlay networking) |
+| `AKS_POD_IPV6_CIDR` | `fd10:59f0:8c79:240::/64` | No | AKS pod network IPv6 CIDR (overlay networking) |
 | `AKS_VNET_IPV4_CIDR` | - | Yes | AKS VNET IPv4 CIDR (for API server and kubelet) |
 | `AKS_VNET_IPV6_CIDR` | - | Yes | AKS VNET IPv6 CIDR (for API server and kubelet) |

--- a/oci/traefik/policies/linkerd-policies.yaml
+++ b/oci/traefik/policies/linkerd-policies.yaml
@@ -13,6 +13,7 @@ spec:
   proxyProtocol: HTTP/1
 ---
 # Network auth for kubelet
+# Includes both pod CIDRs (overlay network) and VNET CIDRs
 apiVersion: policy.linkerd.io/v1alpha1
 kind: NetworkAuthentication
 metadata:
@@ -20,6 +21,8 @@ metadata:
   namespace: traefik
 spec:
   networks:
+    - cidr: ${AKS_POD_IPV4_CIDR:=10.240.0.0/16}
+    - cidr: ${AKS_POD_IPV6_CIDR:=fd10:59f0:8c79:240::/64}
     - cidr: ${AKS_VNET_IPV4_CIDR}
     - cidr: ${AKS_VNET_IPV6_CIDR}
 ---


### PR DESCRIPTION
Add AKS_POD_IPV4_CIDR and AKS_POD_IPV6_CIDR (with defaults) and include pod CIDRs in the Linkerd NetworkAuthentication for kubelet. Update README and policies docs to document the new variables and mention Linkerd proxy admin health checks on port 4191.