### PR TITLE
Feat(whoami): add whoami-mesh HTTPRoute and docs

### DIFF
--- a/oci/whoami/policies/whoami-policies.yaml
+++ b/oci/whoami/policies/whoami-policies.yaml
@@ -65,6 +65,23 @@ spec:
         - path:
             value: /health
 ---
+# Catch-all route for meshed traffic (all paths)
+apiVersion: policy.linkerd.io/v1beta3
+kind: HTTPRoute
+metadata:
+  name: whoami-mesh
+  namespace: whoami
+spec:
+  parentRefs:
+    - group: policy.linkerd.io
+      kind: Server
+      name: whoami-http
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+---
 # Allow meshed traffic to whoami HTTP (all paths)
 apiVersion: policy.linkerd.io/v1alpha1
 kind: AuthorizationPolicy
@@ -74,8 +91,8 @@ metadata:
 spec:
   targetRef:
     group: policy.linkerd.io
-    kind: Server
-    name: whoami-http
+    kind: HTTPRoute
+    name: whoami-mesh
   requiredAuthenticationRefs:
     - group: policy.linkerd.io
       kind: MeshTLSAuthentication


### PR DESCRIPTION
Add a v1beta3 HTTPRoute "whoami-mesh" as a catch-all for meshed traffic and update the AuthorizationPolicy to target the HTTPRoute instead of the Server. Add a health route/policy and README notes explaining v1beta3
Server routing behavior and why both catch-all and /health routes are required.