### PR TITLE
feat: Add releaseName to multitenancy HelmReleases

### DIFF
--- a/oci/azure-service-operator/base/helm-release.yaml
+++ b/oci/azure-service-operator/base/helm-release.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   interval: 1h
   targetNamespace: azureserviceoperator-system
+  releaseName: azure-service-operator
   dependsOn:
     - name: cert-manager
       namespace: cert-manager

--- a/oci/blackbox-exporter/base/helmrelease.yaml
+++ b/oci/blackbox-exporter/base/helmrelease.yaml
@@ -59,6 +59,7 @@ spec:
                 path: /spec/labelValueLengthLimit
                 value: 1023
   targetNamespace: monitoring
+  releaseName: prometheus-blackbox-exporter
   values:
     image:
       registry: altinncr.azurecr.io/quay.io

--- a/oci/external-secrets-operator/multitenancy/kustomization.yaml
+++ b/oci/external-secrets-operator/multitenancy/kustomization.yaml
@@ -22,3 +22,6 @@ patches:
       - op: add
         path: /spec/targetNamespace
         value: external-secrets
+      - op: add
+        path: /spec/releaseName
+        value: external-secrets

--- a/oci/kyverno-policies/multitenancy/kustomization.yaml
+++ b/oci/kyverno-policies/multitenancy/kustomization.yaml
@@ -21,3 +21,6 @@ patches:
       - op: add
         path: /spec/targetNamespace
         value: kyverno
+      - op: add
+        path: /spec/releaseName
+        value: kyverno-policies

--- a/oci/kyverno/multitenancy/kustomization.yaml
+++ b/oci/kyverno/multitenancy/kustomization.yaml
@@ -21,3 +21,6 @@ patches:
       - op: add
         path: /spec/targetNamespace
         value: kyverno
+      - op: add
+        path: /spec/releaseName
+        value: kyverno

--- a/oci/otel-operator/multitenancy/kustomization.yaml
+++ b/oci/otel-operator/multitenancy/kustomization.yaml
@@ -21,3 +21,6 @@ patches:
       - op: add
         path: /spec/targetNamespace
         value: monitoring
+      - op: add
+        path: /spec/releaseName
+        value: dis-otel-operator

--- a/oci/traefik/multitenancy/kustomization.yaml
+++ b/oci/traefik/multitenancy/kustomization.yaml
@@ -27,12 +27,18 @@ patches:
       name: traefik-crds
     patch: |
       - op: add
+        path: /spec/releaseName
+        value: traefik-crds
+      - op: add
         path: /spec/values/gatewayAPI
         value: true
   - target:
       kind: HelmRelease
       name: altinn-traefik
     patch: |
+      - op: add
+        path: /spec/releaseName
+        value: altinn-traefik
       - op: replace
         path: /spec/dependsOn
         value:


### PR DESCRIPTION
Ensure releaseName is set whenever targetNamespace is added so Flux does not compose "<targetNamespace>-<name>" and produce doubly-prefixed resource names. Affected packages: azure-service-operator, blackbox-exporter, external-secrets-operator, kyverno-policies, kyverno, otel-operator, traefik.

A big reason for this change is to make overlay deployments with targetnamespace get same name in cluster as overlays without targetnamespace. i.e. serviceaccount name can get different name from helm, and that makes it more hard to create standard federated identities.