### PR TITLE
chore(dis-pgsql): force renovate to fetch semver from source

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -26,8 +26,25 @@
       "matchPackageNames": [
         "ghcr.io/altinn/altinn-platform/dis-pgsql-operator"
       ],
+      "versioning": "semver",
+      "allowedVersions": "/^v?\\d+\\.\\d+\\.\\d+$/",
       "groupName": "dis pgsql operator image tags",
       "groupSlug": "dis-pgsql-operator-tags"
+    },
+    {
+      "matchManagers": [
+        "custom.regex"
+      ],
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchPackageNames": [
+        "ghcr.io/altinn/altinn-platform/dis-pgsql-operator"
+      ],
+      "matchUpdateTypes": [
+        "pin"
+      ],
+      "enabled": false
     },
     {
       "matchDatasources": [


### PR DESCRIPTION
Currently renovate is trying to get the updates in ghcr.io/altinn/altinn-platform  by the sha of the image, but we need to get the semver as that's what we use.
