### PR TITLE
chore(renovate): avoid all source except semver from ghcr

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,9 +17,6 @@
   ],
   "packageRules": [
     {
-      "matchManagers": [
-        "custom.regex"
-      ],
       "matchDatasources": [
         "docker"
       ],
@@ -28,13 +25,11 @@
       ],
       "versioning": "semver",
       "allowedVersions": "/^v?\\d+\\.\\d+\\.\\d+$/",
+      "pinDigests": false,
       "groupName": "dis pgsql image tags",
       "groupSlug": "dis-pgsql-tags"
     },
     {
-      "matchManagers": [
-        "custom.regex"
-      ],
       "matchDatasources": [
         "docker"
       ],
@@ -42,7 +37,9 @@
         "ghcr.io/altinn/altinn-platform/dis-pgsql-operator"
       ],
       "matchUpdateTypes": [
-        "pin"
+        "pin",
+        "pinDigest",
+        "digest"
       ],
       "enabled": false
     },


### PR DESCRIPTION
previous changes didn't work, this is another attempt to stop checking for non semver update in ghcr