### PR TITLE
feat(headscale): update DNS and add split zones

### DIFF
--- a/oci/headscale/config-secret.yaml
+++ b/oci/headscale/config-secret.yaml
@@ -48,8 +48,13 @@ stringData:
       override_local_dns: true
       nameservers:
         global:
-          - 1.1.1.2
-          - 2606:4700:4700::1112
+          - 1.1.1.3
+          - 2606:4700:4700::1113
+        split:
+          postgres.database.azure.com:
+            - 168.63.129.16
+          privatelink.postgres.database.azure.com:
+            - 168.63.129.16
       search_domains:
         - altinn.cloud
       magic_dns: true


### PR DESCRIPTION
Replace Cloudflare secondary nameserver 1.1.1.2 and 2606:4700:4700::1112 with 1.1.1.3 and 2606:4700:4700::1113. Add split DNS entries for postgres.database.azure.com and privatelink.postgres.database.azure.com pointing to 168.63.129.16.