### PR TITLE
fix(lakmus): update oci path

### DIFF
--- a/oci/lakmus/flux-kustomize.yaml
+++ b/oci/lakmus/flux-kustomize.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   force: false
   interval: 5m0s
-  path: ./default
+  path: ./
   prune: false
   retryInterval: 5m0s
   images:


### PR DESCRIPTION
path was set to default/. The configuration pushed is located at root of the image ref: https://github.com/Altinn/altinn-platform/blob/main/.github/workflows/lakmus-release.yml#L65

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified deployment configuration to apply Flux Kustomizations from the repository root instead of a designated subdirectory. This updates the source path for automated deployment synchronization while maintaining all existing synchronization intervals, retry policies, and namespace targeting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->