### PR TITLE
chore: authorize the github user editing issue

### DIFF
--- a/.github/workflows/flux-manage-releases.yml
+++ b/.github/workflows/flux-manage-releases.yml
@@ -159,6 +159,10 @@ jobs:
     steps:
       - name: Authorize user
         id: check_user_auth
+        env:
+          ISSUE_ACTOR_ID: ${{ github.actor_id }}
+          ISSUE_ACTOR: ${{ github.actor }}
+          TRIGGER_ACTOR: ${{ github.triggering_actor }}
         run: |
           # Using actor_id as github reccomends using the immutable actor_id
           # Add record here to map between username and actor_id (Found by using github api: https://api.github.com/users/<username>)
@@ -175,9 +179,9 @@ jobs:
           # EivindBRisa 164244096
           # tjololo 1145298
           AUTHORIZED_USER_IDS=("1777366" "6243408" "8321743" "12184124" "32734566" "45536168" "49302758" "56063468" "62640845" "89203237" "164244096" "1145298")
-          EDIT_AUTHOR=${{ github.actor_id }}
-          ACTOR=${{ github.actor }}
-          TRIGGER_AUTHOR=${{ github.triggering_actor }}
+          EDIT_AUTHOR="${ISSUE_ACTOR_ID}"
+          ACTOR="${ISSUE_ACTOR}"
+          TRIGGER_AUTHOR="${TRIGGER_ACTOR}"
           if [ "$ACTOR" != "$TRIGGER_AUTHOR" ]; then
             echo "Actor ($ACTOR) and triggering actor ($TRIGGER_AUTHOR) differ. Exiting."
             exit 1


### PR DESCRIPTION
This pull request adds an authorization step to the `flux-manage-releases` GitHub Actions workflow to ensure only specific users can trigger the workflow when editing relevant issues. This helps improve security and control over who can promote releases via the workflow.

Workflow security enhancement:

* Added a shell script step named "Authorize user" to check if the user editing the issue is in a hardcoded list of authorized users, failing the job if not authorized. (`.github/workflows/flux-manage-releases.yml`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a pre-execution authorization check to release-management workflows: only a configured list of approved user IDs can proceed with creating release issues and release PRs. Triggers are validated early and unauthorized attempts are halted to reduce accidental or unauthorized release actions and ensure only authorized initiators can advance the release process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->