### PR TITLE
chore: add PR validation with kustomize diff

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   kustomize-diff:
-    uses: dis-way/actions/.github/workflows/kustomize-diff.yml@arealmaas/marseille
+    uses: dis-way/actions/.github/workflows/kustomize-diff.yml@main
     with:
       build-paths: "oci/*,oci/*/apps,oci/*/multitenancy,oci/*/adminservices"
     permissions:

--- a/oci/whoami/kustomization.yaml
+++ b/oci/whoami/kustomization.yaml
@@ -2,6 +2,3 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - base
-labels:
-  - pairs:
-      kustomize-diff-test: enabled


### PR DESCRIPTION
## Summary

- Adds a `pull-request.yml` workflow that calls the reusable kustomize-diff workflow from `dis-way/.github`
- Builds all kustomize targets under `oci/*` and posts a diff comment on PRs
- References `@arealmaas/dublin` branch for immediate testing — will update to `@main` after https://github.com/dis-way/.github/pull/4 merges
- Adds a test label in `oci/whoami` to produce a visible diff on this PR

## Test plan

- [ ] Confirm kustomize diff comment appears on this PR
- [ ] Update ref to `@main` after dis-way/.github PR merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a pull request CI workflow to automate checks and ensure single in-progress run per PR.
  * Updated infrastructure configuration to attach a metadata label to resources to aid automated tooling and filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->