### PR TITLE
fix[opencost): use env vars instead of args

### DIFF
--- a/oci/opencost/base/helm-release.yaml
+++ b/oci/opencost/base/helm-release.yaml
@@ -40,7 +40,7 @@ spec:
             - name: TARGET_HOST
               value: "${AZURE_PROMETHEUS_ENDPOINT}"
             - name: LISTENING_PORT
-              value: 8080
+              value: "8080"
           ports:
             - containerPort: 8080
               name: proxy


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched service configuration from hard-coded command arguments to environment-variable based settings for the auth proxy container.
  * Added CPU/memory resource requests and limits for the auth proxy container; container port mapping remains unchanged.
  * No public or exported interfaces were modified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->