### PR TITLE
fix(opencost): use env vars instead of args

### DIFF
--- a/oci/opencost/base/helm-release.yaml
+++ b/oci/opencost/base/helm-release.yaml
@@ -4,7 +4,7 @@ metadata:
   name: opencost
   namespace: opencost-system
 spec:
-  interval: 1h
+  interval: 4h
   releaseName: opencost
   targetNamespace: opencost-system
   install:


### PR DESCRIPTION
Dummy change to trigger release please. Original change in PR: #689 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted reconciliation interval configuration, increasing the time between automatic synchronization cycles from 1 hour to 4 hours.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->