### PR TITLE
chore: Add privatelink DNS entries to headscale config

### DIFF
--- a/oci/headscale/config-secret.yaml
+++ b/oci/headscale/config-secret.yaml
@@ -59,6 +59,10 @@ stringData:
             - 168.63.129.16
           private.westeurope.azmk8s.io:
             - 168.63.129.16
+          privatelink.redis.cache.windows.net:
+            - 168.63.129.16
+          privatelink.servicebus.windows.net:
+            - 168.63.129.16
       search_domains:
         - altinn.cloud
       magic_dns: true


### PR DESCRIPTION
Add privatelink.redis.cache.windows.net and
privatelink.servicebus.windows.net to headscale config-secret so Azure Private Link DNS resolves to 168.63.129.16

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated DNS configuration to support private endpoint connectivity for cloud services, improving network routing and service accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->