### PR TITLE
Fix(tailscale-subnet-router): Mount /root/.cache

### DIFF
--- a/oci/tailscale-subnet-router/base/deployment.yaml
+++ b/oci/tailscale-subnet-router/base/deployment.yaml
@@ -64,6 +64,10 @@ spec:
           volumeMounts:
             - name: tmp
               mountPath: /tmp
+            - name: root-cache
+              mountPath: /root/.cache
       volumes:
         - name: tmp
+          emptyDir: {}
+        - name: root-cache
           emptyDir: {}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Tailscale subnet router deployment configuration to add cache volume support for improved container operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->