### PR TITLE
fix(tailscale-subnet-router): Add /var/run mount

### DIFF
--- a/oci/tailscale-subnet-router/base/deployment.yaml
+++ b/oci/tailscale-subnet-router/base/deployment.yaml
@@ -66,8 +66,12 @@ spec:
               mountPath: /tmp
             - name: root-cache
               mountPath: /root/.cache
+            - name: var-run-tailscale
+              mountPath: /var/run/tailscale
       volumes:
         - name: tmp
           emptyDir: {}
         - name: root-cache
+          emptyDir: {}
+        - name: var-run-tailscale
           emptyDir: {}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container configuration to properly handle temporary runtime resources for the Tailscale component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->