### PR TITLE
fix: allow all pods to send otel data

### DIFF
--- a/oci/otel-collector/policies/ingress-policy.yaml
+++ b/oci/otel-collector/policies/ingress-policy.yaml
@@ -5,11 +5,12 @@ metadata:
   name: otel-collector-grpc
   namespace: monitoring
 spec:
+  accessPolicy: cluster-unauthenticated
   podSelector:
     matchLabels:
       app.kubernetes.io/name: otel-collector
   port: 4317
-  proxyProtocol: gRPC
+  proxyProtocol: unknown
 ---
 apiVersion: policy.linkerd.io/v1beta3
 kind: Server
@@ -17,47 +18,9 @@ metadata:
   name: otel-collector-http
   namespace: monitoring
 spec:
+  accessPolicy: cluster-unauthenticated
   podSelector:
     matchLabels:
       app.kubernetes.io/name: otel-collector
   port: 4318
   proxyProtocol: unknown
----
-apiVersion: policy.linkerd.io/v1alpha1
-kind: MeshTLSAuthentication
-metadata:
-  name: allow-all-meshed
-  namespace: monitoring
-spec:
-  identities:
-    - "*"
----
-apiVersion: policy.linkerd.io/v1alpha1
-kind: AuthorizationPolicy
-metadata:
-  name: otel-collector-ingress
-  namespace: monitoring
-spec:
-  targetRef:
-    group: policy.linkerd.io
-    kind: Server
-    name: otel-collector-grpc
-  requiredAuthenticationRefs:
-    - group: policy.linkerd.io
-      kind: MeshTLSAuthentication
-      name: allow-all-meshed
----
-apiVersion: policy.linkerd.io/v1alpha1
-kind: AuthorizationPolicy
-metadata:
-  name: otel-collector-ingress-http
-  namespace: monitoring
-spec:
-  targetRef:
-    group: policy.linkerd.io
-    kind: Server
-    name: otel-collector-http
-  requiredAuthenticationRefs:
-    - group: policy.linkerd.io
-      kind: MeshTLSAuthentication
-      name: allow-all-meshed


### PR DESCRIPTION
Updated ingress policies for otel-collector to use cluster-unauthenticated access policy and changed proxyProtocol to unknown. Removed MeshTLSAuthentication and AuthorizationPolicy configurations as we now allow all to send to the otel-collector