### PR TITLE
feat(tailscale): Use Recreate strategy and RBAC

### DIFF
--- a/oci/tailscale-subnet-router/base/deployment.yaml
+++ b/oci/tailscale-subnet-router/base/deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: tailscale-subnet-router
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: tailscale-subnet-router

--- a/oci/tailscale-subnet-router/base/serviceaccount.yaml
+++ b/oci/tailscale-subnet-router/base/serviceaccount.yaml
@@ -15,8 +15,11 @@ rules:
     resourceNames: ["tailscale-state"]
     verbs: ["get", "update", "patch"]
   - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get"]
+  - apiGroups: [""]
     resources: ["events"]
-    verbs: ["get", "create", "patch"]
+    verbs: ["create", "patch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
Set Deployment.strategy.type to Recreate to force pod restart on updates.

Adjust Role rules: add get permission for pods and remove get from events,
leaving only create and patch for events.

Release-As: 1.0.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure Updates**
  * Updated deployment strategy for Tailscale subnet router from rolling updates to recreate mode, changing how service updates are applied during deployments.

* **Permissions Updates**
  * Modified role-based access control permissions to enable pod information access and adjusted event permissions within the system namespace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->