### PR TITLE
fix: kyverno should ignore linkerd namespace

### DIFF
--- a/oci/kyverno/base/helmrelease.yaml
+++ b/oci/kyverno/base/helmrelease.yaml
@@ -58,6 +58,7 @@ spec:
             - kube-public
             - kube-node-lease
             - flux-system
+            - linkerd
     features:
       policyExceptions:
         enabled: true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated policy enforcement configuration to exclude the `linkerd` namespace from webhook processing. The Linkerd service mesh namespace is now part of the exclusion list alongside other system namespaces, ensuring Linkerd components operate independently without policy constraints that could impact service mesh functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->