### PR TITLE
feat: add traefik crd patch package

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -11,6 +11,7 @@
   "oci/dis-tls-cert": "2.8.0",
   "oci/external-secrets-operator": "1.6.2",
   "oci/grafana-operator": "2.1.3",
+  "oci/traefik-crd-patch": "1.0.0",
   "oci/headscale": "1.7.0",
   "oci/kyverno-policies": "1.4.1",
   "oci/kyverno": "1.3.2",

--- a/oci/releaseconfig.json
+++ b/oci/releaseconfig.json
@@ -87,6 +87,14 @@
     "prod_ring1": "1.6.2",
     "prod_ring2": "1.6.2"
   },
+  "traefik-crd-patch": {
+    "at_ring1": "1.0.0",
+    "at_ring2": "1.0.0",
+    "tt_ring1": "1.0.0",
+    "tt_ring2": "1.0.0",
+    "prod_ring1": "1.0.0",
+    "prod_ring2": "1.0.0"
+  },
   "grafana-operator": {
     "at_ring1": "2.1.3",
     "at_ring2": "2.1.3",

--- a/oci/traefik-crd-patch/kustomization.yaml
+++ b/oci/traefik-crd-patch/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - patch.yaml

--- a/oci/traefik-crd-patch/patch.yaml
+++ b/oci/traefik-crd-patch/patch.yaml
@@ -1,0 +1,61 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: traefik-crd-patch
+  namespace: traefik
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: traefik-crd-patch
+rules:
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions/status"]
+    verbs: ["get", "patch"]
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: traefik-crd-patch
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: traefik-crd-patch
+subjects:
+  - kind: ServiceAccount
+    name: traefik-crd-patch
+    namespace: traefik
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: traefik-crd-patch
+  namespace: traefik
+spec:
+  template:
+    spec:
+      serviceAccountName: traefik-crd-patch
+      restartPolicy: OnFailure
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: kubectl
+          image: altinncr.azurecr.io/docker.io/bitnami/kubectl:latest
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              kubectl get crd grpcroutes.gateway.networking.k8s.io 2>/dev/null || exit 0
+              kubectl patch crd grpcroutes.gateway.networking.k8s.io \
+                --type=json \
+                --subresource=status \
+                -p '[{"op":"replace","path":"/status/storedVersions","value":["v1"]}]'
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -48,6 +48,10 @@
       "release-type": "simple",
       "component": "oci-grafana-operator"
     },
+    "oci/traefik-crd-patch": {
+      "release-type": "simple",
+      "component": "oci-traefik-crd-patch"
+    },
     "oci/headscale": {
       "release-type": "simple",
       "component": "oci-headscale"


### PR DESCRIPTION
grpcroutes.gateway.networking.k8s.io have immutable version that needs to be patched for traefik to be able to upgrade. this package have job that patch crd.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced Traefik CRD patch (v1.0.0) that automatically corrects stored versions for gRPC routes custom resources across all environments.

* **Chores**
  * Added release configuration and deployment setup for the Traefik CRD patch component across staging and production rings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->