### PR TITLE
feat: Enable Auth-Once and raise memory request

### DIFF
--- a/oci/tailscale-subnet-router/base/deployment.yaml
+++ b/oci/tailscale-subnet-router/base/deployment.yaml
@@ -42,6 +42,8 @@ spec:
               value: "true"
             - name: TS_KUBE_SECRET
               value: "tailscale-state"
+            - name: TS_AUTH_ONCE
+              value: "true"
             - name: TS_ACCEPT_DNS
               value: "false"
             - name: TS_HOSTNAME
@@ -57,10 +59,7 @@ spec:
           resources:
             requests:
               cpu: 50m
-              memory: 64Mi
-            limits:
-              cpu: 500m
-              memory: 128Mi
+              memory: 192Mi
           livenessProbe:
             exec:
               command:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Tailscale subnet router container resource allocation with increased memory (192Mi) and adjusted deployment settings. Removed resource limits and enhanced authentication configuration for optimized operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->