### PR TITLE
feat(headscale): support extra DNS records

### DIFF
--- a/oci/headscale/README.md
+++ b/oci/headscale/README.md
@@ -13,6 +13,26 @@ Self-hosted Tailscale control server providing WireGuard-based VPN mesh networki
 | `HEADSCALE_APP_CLIENT_SECRET` | - | Yes | Microsoft Entra OIDC client secret — source from a secret store, not plain substitution |
 | `HEADSCALE_APP_ALLOWED_GROUP` | - | Yes | Microsoft Entra group allowed for access |
 
+## Extra DNS Records
+
+Extra DNS records are served to Tailscale clients via headscale. By default, the `headscale-extra-records` ConfigMap contains an empty array. Patch it in your overlay to add static entries:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: headscale-extra-records
+  namespace: headscale
+data:
+  extra-records.json: |
+    [
+      {"name": "grafana.ts.altinn.cloud", "type": "A", "value": "100.70.0.3"},
+      {"name": "prometheus.ts.altinn.cloud", "type": "A", "value": "100.70.0.4"}
+    ]
+```
+
+Headscale polls `extra-records.json` via checksum and picks up changes without a restart. Sort the JSON keys and records to produce stable output when generating the file with a script.
+
 ## Prerequisites
 
 ### DNS

--- a/oci/headscale/config-secret.yaml
+++ b/oci/headscale/config-secret.yaml
@@ -69,6 +69,7 @@ stringData:
         - altinn.cloud
       magic_dns: true
       base_domain: ts.altinn.cloud
+      extra_records_path: /etc/headscale-extra/extra-records.json
     policy:
       mode: "database"
     oidc:

--- a/oci/headscale/deployment.yaml
+++ b/oci/headscale/deployment.yaml
@@ -76,6 +76,9 @@ spec:
               mountPath: /var/lib/headscale
             - name: run
               mountPath: /var/run/headscale
+            - name: extra-records
+              mountPath: /etc/headscale-extra
+              readOnly: true
       volumes:
         - name: config
           secret:
@@ -85,3 +88,6 @@ spec:
             claimName: headscale-data
         - name: run
           emptyDir: {}
+        - name: extra-records
+          configMap:
+            name: headscale-extra-records

--- a/oci/headscale/extra-records-configmap.yaml
+++ b/oci/headscale/extra-records-configmap.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: headscale-extra-records
+  namespace: headscale
+data:
+  extra-records.json: |
+    []

--- a/oci/headscale/extra-records-configmap.yaml
+++ b/oci/headscale/extra-records-configmap.yaml
@@ -5,4 +5,7 @@ metadata:
   namespace: headscale
 data:
   extra-records.json: |
-    []
+    [
+      {"name": "infop-at22-vllfov-server.privatelink.database.windows.net", "type": "A", "value": "10.205.143.5"},
+      {"name": "infop-prod-hxhapc-server.privatelink.database.windows.net", "type": "A", "value": "10.205.15.4"}
+    ]

--- a/oci/headscale/kustomization.yaml
+++ b/oci/headscale/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   - namespace.yaml
   - storageclass.yaml
   - config-secret.yaml
+  - extra-records-configmap.yaml
   - pvc.yaml
   - deployment.yaml
   - service.yaml


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for providing additional static DNS records to Tailscale clients through headscale. Configuration changes are automatically reloaded without requiring service restarts.

* **Documentation**
  * Added guidance on configuring and managing extra DNS records via ConfigMap with example patches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->