### PR TITLE
feat: Refactor TS_ADVERTISE_ROUTES into separate env var

### DIFF
--- a/oci/tailscale-subnet-router/base/deployment.yaml
+++ b/oci/tailscale-subnet-router/base/deployment.yaml
@@ -37,7 +37,9 @@ spec:
                   name: tailscale-authkey
                   key: TS_AUTHKEY
             - name: TS_EXTRA_ARGS
-              value: "--login-server=https://headscale.altinn.cloud --advertise-routes=${TS_ADVERTISE_ROUTES:=}"
+              value: "--login-server=https://headscale.altinn.cloud"
+            - name: TS_ROUTES
+              value: "${TS_ADVERTISE_ROUTES:=}"
             - name: TS_USERSPACE
               value: "true"
             - name: TS_KUBE_SECRET


### PR DESCRIPTION
Split the advertise routes configuration from TS_EXTRA_ARGS into a dedicated TS_ROUTES environment variable for better clarity and maintainability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Restructured Tailscale deployment configuration to use a dedicated environment variable for route advertisement settings instead of embedding them within general arguments. This improves configuration organization and clarity while maintaining the same functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->