### PR TITLE
fix: update kro release version to 0.2.0

### DIFF
--- a/oci/releaseconfig.json
+++ b/oci/releaseconfig.json
@@ -112,12 +112,12 @@
     "prod_ring2": "2.1.3"
   },
   "kro": {
-    "at_ring1": "0.1.0",
-    "at_ring2": "0.1.0",
-    "tt_ring1": "0.1.0",
-    "tt_ring2": "0.1.0",
-    "prod_ring1": "0.1.0",
-    "prod_ring2": "0.1.0"
+    "at_ring1": "0.2.0",
+    "at_ring2": "0.2.0",
+    "tt_ring1": "0.2.0",
+    "tt_ring2": "0.2.0",
+    "prod_ring1": "0.2.0",
+    "prod_ring2": "0.2.0"
   },
   "kyverno": {
     "at_ring1": "1.3.2",


### PR DESCRIPTION
- Update kro version from 0.1.0 to 0.2.0 in releaseconfig.json for all environments
- The previous 0.1.0 entry was added before the OCI artifact was published, causing the promote workflow to fail with MANIFEST_UNKNOWN
- Now points to the actually published 0.2.0 artifact so ring promotion can succeed