### PR TITLE
feat: Add DIS environment targets to uptime monitoring

### DIFF
--- a/oci/altinn-uptime/configmaps/extra-targets.yaml
+++ b/oci/altinn-uptime/configmaps/extra-targets.yaml
@@ -17,14 +17,20 @@ data:
         "https://grafana.altinn.cloud/whoami",
         "https://info.altinn.no",
         "https://prod.admin.altinn.cloud/whoami",
-        "https://at22.dis-core.altinn.cloud/whoami"
+        "https://at22.dis-core.altinn.cloud/whoami",
+        "https://at23.dis-core.altinn.cloud/whoami",
+        "https://tt02.dis-core.altinn.cloud/whoami",
+        "https://prod.dis-core.altinn.cloud/whoami"
       ],
       "ipv6": [
         "https://altinncdn.no/orgs/altinn-orgs.json",
         "https://grafana.altinn.cloud/whoami",
         "https://info.altinn.no",
         "https://prod.admin.altinn.cloud/whoami",
-        "https://at22.dis-core.altinn.cloud/whoami"
+        "https://at22.dis-core.altinn.cloud/whoami",
+        "https://at23.dis-core.altinn.cloud/whoami",
+        "https://tt02.dis-core.altinn.cloud/whoami",
+        "https://prod.dis-core.altinn.cloud/whoami"
       ],
       "kuberneteswrapper_ipv4": [
         "https://platform.tt02.altinn.no/kuberneteswrapper/api/v1/deployments",


### PR DESCRIPTION
Add uptime monitoring targets for at23, tt02, and prod DIS core environments to both IPv4 and IPv6 probe lists.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended uptime monitoring coverage by adding four new endpoints across deployment environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->