### PR TITLE
feat: Add ActiveMQ OCI package for eFormidling messaging

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,5 @@
 {
+  "oci/activemq": "1.0.0",
   "oci/altinn-uptime": "1.7.0",
   "oci/azure-service-operator": "1.4.2",
   "oci/blackbox-exporter": "0.7.7",

--- a/oci/activemq/README.md
+++ b/oci/activemq/README.md
@@ -1,6 +1,10 @@
 # ActiveMQ
 
-Deploys ActiveMQ 5.15.9 (`activemq-eformidling`) for eFormidling messaging with a persistent volume for broker data.
+Deploys ActiveMQ Classic (`activemq-eformidling`) as an external message broker for eFormidling, with a persistent volume for broker data.
+
+## Variables
+
+None — all configuration is static in the manifests.
 
 ## Layers
 

--- a/oci/activemq/README.md
+++ b/oci/activemq/README.md
@@ -1,0 +1,11 @@
+# ActiveMQ
+
+Deploys ActiveMQ 5.15.9 (`activemq-eformidling`) for eFormidling messaging with a persistent volume for broker data.
+
+## Layers
+
+| Path | Description |
+|------|-------------|
+| `base` | Namespace, StorageClass, PVC, Deployment, and Service |
+| `staging` | Overrides PVC storage to 2Gi |
+| `prod` | Overrides PVC storage to 20Gi and increases CPU/memory limits |

--- a/oci/activemq/base/deployment.yaml
+++ b/oci/activemq/base/deployment.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: activemq-eformidling
+  namespace: activemq
+  labels:
+    app: activemq-eformidling
+spec:
+  replicas: 1
+  revisionHistoryLimit: 1
+  selector:
+    matchLabels:
+      app: activemq-eformidling
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: activemq-eformidling
+      annotations:
+        linkerd.io/inject: enabled
+    spec:
+      containers:
+        - name: activemq
+          # renovate: datasource=docker depName=rmohr/activemq
+          image: altinncr.azurecr.io/docker.io/rmohr/activemq:5.15.9
+          ports:
+            - name: openwire
+              containerPort: 61616
+              protocol: TCP
+            - name: webconsole
+              containerPort: 8161
+              protocol: TCP
+          resources:
+            requests:
+              cpu: 100m
+              memory: 512Mi
+            limits:
+              memory: 1Gi
+          volumeMounts:
+            - name: data
+              mountPath: /opt/activemq/data
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: activemq-eformidling-data

--- a/oci/activemq/base/deployment.yaml
+++ b/oci/activemq/base/deployment.yaml
@@ -22,8 +22,8 @@ spec:
     spec:
       containers:
         - name: activemq
-          # renovate: datasource=docker depName=rmohr/activemq
-          image: altinncr.azurecr.io/docker.io/rmohr/activemq:5.15.9
+          # renovate: datasource=docker depName=apache/activemq-classic
+          image: altinncr.azurecr.io/docker.io/apache/activemq-classic:5.19.2
           ports:
             - name: openwire
               containerPort: 61616

--- a/oci/activemq/base/deployment.yaml
+++ b/oci/activemq/base/deployment.yaml
@@ -31,6 +31,17 @@ spec:
             - name: webconsole
               containerPort: 8161
               protocol: TCP
+          readinessProbe:
+            tcpSocket:
+              port: 61616
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: 61616
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            failureThreshold: 3
           resources:
             requests:
               cpu: 100m

--- a/oci/activemq/base/kustomization.yaml
+++ b/oci/activemq/base/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - storageclass.yaml
+  - pvc.yaml
+  - deployment.yaml
+  - service.yaml

--- a/oci/activemq/base/namespace.yaml
+++ b/oci/activemq/base/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: activemq

--- a/oci/activemq/base/pvc.yaml
+++ b/oci/activemq/base/pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: activemq-eformidling-data
+  namespace: activemq
+spec:
+  storageClassName: activemq-data
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi

--- a/oci/activemq/base/service.yaml
+++ b/oci/activemq/base/service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: activemq-eformidling
+  namespace: activemq
+  labels:
+    app: activemq-eformidling
+spec:
+  ports:
+    - name: openwire
+      port: 61616
+      protocol: TCP
+      targetPort: 61616
+    - name: webconsole
+      port: 8161
+      protocol: TCP
+      targetPort: 8161
+  selector:
+    app: activemq-eformidling
+  type: ClusterIP

--- a/oci/activemq/base/storageclass.yaml
+++ b/oci/activemq/base/storageclass.yaml
@@ -1,0 +1,10 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: activemq-data
+provisioner: disk.csi.azure.com
+reclaimPolicy: Retain
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+parameters:
+  skuName: StandardSSD_ZRS

--- a/oci/activemq/kustomization.yaml
+++ b/oci/activemq/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - base

--- a/oci/activemq/prod/kustomization.yaml
+++ b/oci/activemq/prod/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base
+patches:
+  - path: pvc-patch.yaml
+    target:
+      kind: PersistentVolumeClaim
+      name: activemq-eformidling-data
+  - path: resource-patch.yaml
+    target:
+      kind: Deployment
+      name: activemq-eformidling

--- a/oci/activemq/prod/pvc-patch.yaml
+++ b/oci/activemq/prod/pvc-patch.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: activemq-eformidling-data
+  namespace: activemq
+spec:
+  resources:
+    requests:
+      storage: 20Gi

--- a/oci/activemq/prod/resource-patch.yaml
+++ b/oci/activemq/prod/resource-patch.yaml
@@ -1,0 +1,16 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: activemq-eformidling
+  namespace: activemq
+spec:
+  template:
+    spec:
+      containers:
+        - name: activemq
+          resources:
+            requests:
+              cpu: 250m
+              memory: 1Gi
+            limits:
+              memory: 2Gi

--- a/oci/activemq/staging/kustomization.yaml
+++ b/oci/activemq/staging/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base
+patches:
+  - path: pvc-patch.yaml
+    target:
+      kind: PersistentVolumeClaim
+      name: activemq-eformidling-data

--- a/oci/activemq/staging/pvc-patch.yaml
+++ b/oci/activemq/staging/pvc-patch.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: activemq-eformidling-data
+  namespace: activemq
+spec:
+  resources:
+    requests:
+      storage: 2Gi

--- a/oci/releaseconfig.json
+++ b/oci/releaseconfig.json
@@ -57,11 +57,11 @@
   },
   "dis-apim": {
     "at_ring1": "0.3.0",
-    "at_ring2": "1.0.0",
-    "tt_ring1": "1.0.0",
-    "tt_ring2": "1.0.0",
-    "prod_ring1": "1.0.0",
-    "prod_ring2": "1.0.0"
+    "at_ring2": "0.1.0",
+    "tt_ring1": "0.1.0",
+    "tt_ring2": "0.1.0",
+    "prod_ring1": "0.1.0",
+    "prod_ring2": "0.1.0"
   },
   "dis-identity": {
     "at_ring1": "0.3.0",

--- a/oci/releaseconfig.json
+++ b/oci/releaseconfig.json
@@ -1,4 +1,12 @@
 {
+  "activemq": {
+    "at_ring1": "1.0.0",
+    "at_ring2": "1.0.0",
+    "tt_ring1": "1.0.0",
+    "tt_ring2": "1.0.0",
+    "prod_ring1": "1.0.0",
+    "prod_ring2": "1.0.0"
+  },
   "altinn-uptime": {
     "at_ring1": "1.7.0",
     "at_ring2": "1.7.0",
@@ -49,11 +57,11 @@
   },
   "dis-apim": {
     "at_ring1": "0.3.0",
-    "at_ring2": "0.1.0",
-    "tt_ring1": "0.1.0",
-    "tt_ring2": "0.1.0",
-    "prod_ring1": "0.1.0",
-    "prod_ring2": "0.1.0"
+    "at_ring2": "1.0.0",
+    "tt_ring1": "1.0.0",
+    "tt_ring2": "1.0.0",
+    "prod_ring1": "1.0.0",
+    "prod_ring2": "1.0.0"
   },
   "dis-identity": {
     "at_ring1": "0.3.0",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,9 @@
 {
   "packages": {
+    "oci/activemq": {
+      "release-type": "simple",
+      "component": "oci-activemq"
+    },
     "oci/altinn-uptime": {
       "release-type": "simple",
       "component": "oci-altinn-uptime"


### PR DESCRIPTION
Includes base deployment with persistent storage, staging overlay (2Gi), and prod overlay (20Gi with increased resources). Registers package in Release Please config and releaseconfig.json. Updates dis-apim versions across all rings to 1.0.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an ActiveMQ deployment with namespace, service, persistent storage, and resource profiles for staging/prod.
  * Exposes OpenWire and web console ports; includes readiness/liveness checks and Linkerd sidecar injection.

* **Configuration**
  * Staging: 2Gi PVC override. Prod: 20Gi PVC and increased CPU/memory requests/limits.
  * Kustomize overlays for base/staging/prod and release mapping entries for the component.

* **Documentation**
  * Added README describing deployment layouts and configuration layers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->