### PR TITLE
feat(linkerd): Add eFormidling AKS overlay

### DIFF
--- a/oci/linkerd/README.md
+++ b/oci/linkerd/README.md
@@ -21,6 +21,7 @@ Deploys Linkerd service mesh with High Availability configuration.
 | `apps` | Standalone overlay that includes only base |
 | `post-deploy` | Rollout restart job for re-injecting proxies after upgrades |
 | `platform-aks` | AKS platform overlay; sets `podMonitor.labels.release: kube-prometheus-stack` for Prometheus discovery |
+| `eformidling-aks` | eFormidling AKS overlay; disables podMonitor and removes post-renderers |
 | `multitenancy` | Multi-tenant overlay with platform-system namespace patches |
 | `policies` | Linkerd authorization policies for control plane (webhooks, health checks, gRPC) |
 

--- a/oci/linkerd/eformidling-aks/kustomization.yaml
+++ b/oci/linkerd/eformidling-aks/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base
+patches:
+  - target:
+      kind: HelmRelease
+      name: linkerd
+    patch: |
+      - op: replace
+        path: /spec/values/podMonitor/enabled
+        value: false
+      - op: remove
+        path: /spec/postRenderers


### PR DESCRIPTION
Add eformidling-aks overlay that disables podMonitor and removes post-renderers for eFormidling AKS deployments.