### PR TITLE
feat: Add eformidling-aks overlays for cert-manager and traefik

### DIFF
--- a/oci/cert-manager/README.md
+++ b/oci/cert-manager/README.md
@@ -14,4 +14,5 @@ No variables. All values are hardcoded in the HelmRelease.
 | `apps` | Alias for `base` |
 | `platform-aks` | AKS platform overlay; currently identical to `base` |
 | `multitenancy` | Moves HelmRepository and HelmRelease to `platform-system` namespace, sets `targetNamespace: cert-manager` and `releaseName: cert-manager` |
--
+| `eformidling-aks` | eFormidling AKS overlay; uses base as-is |
+

--- a/oci/cert-manager/eformidling-aks/kustomization.yaml
+++ b/oci/cert-manager/eformidling-aks/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base

--- a/oci/traefik/README.md
+++ b/oci/traefik/README.md
@@ -13,10 +13,10 @@ CRDs (Traefik and Gateway API standard channel) are managed directly by the Helm
 | `PUBLIC_IP_V6` | — | Not platform-aks | Public IPv6 address for the Azure Load Balancer |
 | `AKS_VNET_IPV4_CIDR` | — | Not platform-aks | Full AKS VNet IPv4 CIDR; trusted for `X-Forwarded-For` |
 | `AKS_VNET_IPV6_CIDR` | — | Not platform-aks | Full AKS VNet IPv6 CIDR; trusted for `X-Forwarded-For` |
-| `AKS_SYSTEM_SUBNET_CIDR` | — | platform-aks only | AKS system node subnet CIDR; trusted for `X-Forwarded-For` |
-| `AKS_WORK_SUBNET_CIDR` | — | platform-aks only | AKS work node subnet CIDR; trusted for `X-Forwarded-For` |
+| `AKS_SYSTEM_SUBNET_CIDR` | — | platform-aks / eformidling-aks | AKS system node subnet CIDR; trusted for `X-Forwarded-For` |
+| `AKS_WORK_SUBNET_CIDR` | — | platform-aks / eformidling-aks | AKS work node subnet CIDR; trusted for `X-Forwarded-For` |
 | `AKS_FILESCAN_SUBNET_CIDR` | — | platform-aks only | AKS filescan node subnet CIDR; trusted for `X-Forwarded-For` |
-| `LB_SOURCE_RANGE_APIM` | — | platform-aks only | Load Balancer source range CIDR for API Management (e.g. `1.2.3.4/32`) |
+| `LB_SOURCE_RANGE_APIM` | — | platform-aks / eformidling-aks | Load Balancer source range CIDR for API Management (e.g. `1.2.3.4/32`) |
 | `LB_SOURCE_RANGE_CORRESPONDENCE` | — | platform-aks only | Load Balancer source range CIDR for correspondence outbound IP |
 | `EXTERNAL_TRAFFIC_POLICY` | `Local` | No | Service `externalTrafficPolicy` |
 | `OTEL_ENDPOINT` | `otel-collector.monitoring.svc.cluster.local:4317` | No | OTLP gRPC endpoint for logs, metrics, and traces |
@@ -33,4 +33,5 @@ CRDs (Traefik and Gateway API standard channel) are managed directly by the Helm
 | `apps` | Standard variant; enables Traefik CRD provider, HSTS applied at entrypoint level via `hsts-header` middleware (`traefik` and `default` namespaces), root catch-all `IngressRoute` returns 418 for unmatched paths |
 | `adminservices` | Gateway API variant (CRD provider also enabled); same HSTS and catch-all setup as `apps`, stays in `traefik` namespace, no Linkerd policies |
 | `multitenancy` | Gateway API variant; Flux resources in `platform-system`, `kubernetesCRD` disabled, four Gateway listeners (http/https + wildcard), Linkerd policies included. **No central HSTS** — `kubernetesCRD` is disabled so `Middleware` CRDs cannot be resolved; HSTS must be applied via `ResponseHeaderModifier` filters on individual `HTTPRoute` resources in downstream apps |
+| `eformidling-aks` | eFormidling AKS overlay; IPv4 single-stack, adds `loadBalancerSourceRanges` (APIM IP), and HSTS middleware |
 | `policies` | Linkerd `Server`, `NetworkAuthentication`, and `AuthorizationPolicy` resources for kubelet probes and proxy admin in deny-all mesh environments; see [`policies/README.md`](policies/README.md) |

--- a/oci/traefik/README.md
+++ b/oci/traefik/README.md
@@ -10,9 +10,9 @@ CRDs (Traefik and Gateway API standard channel) are managed directly by the Helm
 |----------|---------|----------|-------------|
 | `AKS_NODE_RG` | — | Yes | Azure Resource Group for AKS nodes (Load Balancer annotation) |
 | `PUBLIC_IP_V4` | — | Yes | Public IPv4 address for the Azure Load Balancer |
-| `PUBLIC_IP_V6` | — | Not platform-aks | Public IPv6 address for the Azure Load Balancer |
-| `AKS_VNET_IPV4_CIDR` | — | Not platform-aks | Full AKS VNet IPv4 CIDR; trusted for `X-Forwarded-For` |
-| `AKS_VNET_IPV6_CIDR` | — | Not platform-aks | Full AKS VNet IPv6 CIDR; trusted for `X-Forwarded-For` |
+| `PUBLIC_IP_V6` | — | Not platform-aks / eformidling-aks | Public IPv6 address for the Azure Load Balancer |
+| `AKS_VNET_IPV4_CIDR` | — | Not platform-aks / eformidling-aks | Full AKS VNet IPv4 CIDR; trusted for `X-Forwarded-For` |
+| `AKS_VNET_IPV6_CIDR` | — | Not platform-aks / eformidling-aks | Full AKS VNet IPv6 CIDR; trusted for `X-Forwarded-For` |
 | `AKS_SYSTEM_SUBNET_CIDR` | — | platform-aks / eformidling-aks | AKS system node subnet CIDR; trusted for `X-Forwarded-For` |
 | `AKS_WORK_SUBNET_CIDR` | — | platform-aks / eformidling-aks | AKS work node subnet CIDR; trusted for `X-Forwarded-For` |
 | `AKS_FILESCAN_SUBNET_CIDR` | — | platform-aks only | AKS filescan node subnet CIDR; trusted for `X-Forwarded-For` |

--- a/oci/traefik/eformidling-aks/kustomization.yaml
+++ b/oci/traefik/eformidling-aks/kustomization.yaml
@@ -1,0 +1,49 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base
+patches:
+  - target:
+      kind: HelmRelease
+      name: altinn-traefik
+    patch: |
+      - op: add
+        path: /spec/values/ports/https/http/middlewares
+        value:
+          - traefik-hsts-header@kubernetescrd
+      - op: add
+        path: /spec/values/service/loadBalancerSourceRanges
+        value:
+          - "${LB_SOURCE_RANGE_APIM}"
+      - op: replace
+        path: /spec/values/service/ipFamilyPolicy
+        value: SingleStack
+      - op: replace
+        path: /spec/values/service/ipFamilies
+        value:
+          - IPv4
+      - op: remove
+        path: /spec/values/service/annotations/service.beta.kubernetes.io~1azure-load-balancer-ipv6
+      - op: replace
+        path: /spec/values/ports/http/forwardedHeaders/trustedIPs
+        value:
+          - "${AKS_SYSTEM_SUBNET_CIDR}"
+          - "${AKS_WORK_SUBNET_CIDR}"
+      - op: replace
+        path: /spec/values/ports/https/forwardedHeaders/trustedIPs
+        value:
+          - "${AKS_SYSTEM_SUBNET_CIDR}"
+          - "${AKS_WORK_SUBNET_CIDR}"
+      - op: add
+        path: /spec/values/extraObjects
+        value:
+          - apiVersion: traefik.io/v1alpha1
+            kind: Middleware
+            metadata:
+              name: hsts-header
+              namespace: traefik
+            spec:
+              headers:
+                stsIncludeSubdomains: true
+                stsSeconds: 63072000
+                stsPreload: true


### PR DESCRIPTION
Update README documentation to reflect the new overlays and their variable requirements. The traefik overlay configures IPv4 single-stack, adds load balancer source ranges for API Management, and enables HSTS middleware.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for new `eformidling-aks` overlay layer for cert-manager and traefik configurations
  * Implemented IPv4 single-stack networking configuration
  * Added HSTS security middleware support

* **Documentation**
  * Updated configuration documentation to reflect new AKS overlay layer support and required environment variables

<!-- end of auto-generated comment: release notes by coderabbit.ai -->