### PR TITLE
deps: update dis-vault-operator to v1.4.2

### DIFF
--- a/oci/dis-vault/base/flux-kustomize.yaml
+++ b/oci/dis-vault/base/flux-kustomize.yaml
@@ -22,7 +22,7 @@ spec:
     - name: controller
       newName: altinncr.azurecr.io/ghcr.io/altinn/altinn-platform/dis-vault-operator
       # renovate: datasource=docker depName=ghcr.io/altinn/altinn-platform/dis-vault-operator versioning=semver
-      newTag: v1.4.1
+      newTag: v1.4.2
   sourceRef:
     kind: OCIRepository
     name: dis-vault-operator

--- a/oci/dis-vault/base/oci-repository.yaml
+++ b/oci/dis-vault/base/oci-repository.yaml
@@ -8,6 +8,6 @@ spec:
   provider: azure
   ref:
     # renovate: datasource=docker depName=ghcr.io/altinn/altinn-platform/dis-vault-operator versioning=semver
-    tag: v1.4.1
+    tag: v1.4.2
   timeout: 5m0s
   url: oci://altinncr.azurecr.io/dis/kustomize/dis-vault-operator


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dis-vault-operator to version v1.4.2 across deployment configuration files to enable deployment of the latest operator version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->