### PR TITLE
feat(traefik): Add HSTS middleware and root ingress route

### DIFF
--- a/oci/traefik/adminservices/hsts-middleware.yaml
+++ b/oci/traefik/adminservices/hsts-middleware.yaml
@@ -1,0 +1,10 @@
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: hsts-header
+  namespace: traefik
+spec:
+  headers:
+    stsIncludeSubdomains: true
+    stsSeconds: 63072000
+    stsPreload: true

--- a/oci/traefik/adminservices/kustomization.yaml
+++ b/oci/traefik/adminservices/kustomization.yaml
@@ -2,6 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../base
+  - hsts-middleware.yaml
+  - root-ingress-route.yaml
 patches:
   - target:
       kind: HelmRelease

--- a/oci/traefik/adminservices/root-ingress-route.yaml
+++ b/oci/traefik/adminservices/root-ingress-route.yaml
@@ -1,0 +1,15 @@
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: root-ingress-route
+  namespace: traefik
+spec:
+  entryPoints:
+    - http
+    - https
+  routes:
+    - kind: Rule
+      match: PathPrefix(`/`)
+      services:
+        - kind: TraefikService
+          name: noop@internal

--- a/oci/traefik/apps/hsts-middleware-default.yaml
+++ b/oci/traefik/apps/hsts-middleware-default.yaml
@@ -1,0 +1,10 @@
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: hsts-header
+  namespace: default
+spec:
+  headers:
+    stsIncludeSubdomains: true
+    stsSeconds: 63072000
+    stsPreload: true

--- a/oci/traefik/apps/hsts-middleware.yaml
+++ b/oci/traefik/apps/hsts-middleware.yaml
@@ -1,0 +1,10 @@
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: hsts-header
+  namespace: traefik
+spec:
+  headers:
+    stsIncludeSubdomains: true
+    stsSeconds: 63072000
+    stsPreload: true

--- a/oci/traefik/apps/kustomization.yaml
+++ b/oci/traefik/apps/kustomization.yaml
@@ -2,6 +2,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../base
+  - hsts-middleware.yaml
+  - hsts-middleware-default.yaml
+  - root-ingress-route.yaml
 patches:
   - target:
       kind: HelmRelease

--- a/oci/traefik/apps/root-ingress-route.yaml
+++ b/oci/traefik/apps/root-ingress-route.yaml
@@ -1,0 +1,15 @@
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: root-ingress-route
+  namespace: traefik
+spec:
+  entryPoints:
+    - http
+    - https
+  routes:
+    - kind: Rule
+      match: PathPrefix(`/`)
+      services:
+        - kind: TraefikService
+          name: noop@internal

--- a/oci/traefik/eformidling-aks/hsts-middleware.yaml
+++ b/oci/traefik/eformidling-aks/hsts-middleware.yaml
@@ -1,0 +1,10 @@
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: hsts-header
+  namespace: traefik
+spec:
+  headers:
+    stsIncludeSubdomains: true
+    stsSeconds: 63072000
+    stsPreload: true

--- a/oci/traefik/eformidling-aks/kustomization.yaml
+++ b/oci/traefik/eformidling-aks/kustomization.yaml
@@ -2,6 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../base
+  - hsts-middleware.yaml
+  - root-ingress-route.yaml
 patches:
   - target:
       kind: HelmRelease

--- a/oci/traefik/eformidling-aks/root-ingress-route.yaml
+++ b/oci/traefik/eformidling-aks/root-ingress-route.yaml
@@ -1,0 +1,15 @@
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: root-ingress-route
+  namespace: traefik
+spec:
+  entryPoints:
+    - http
+    - https
+  routes:
+    - kind: Rule
+      match: PathPrefix(`/`)
+      services:
+        - kind: TraefikService
+          name: noop@internal

--- a/oci/traefik/platform-aks/hsts-middleware.yaml
+++ b/oci/traefik/platform-aks/hsts-middleware.yaml
@@ -1,0 +1,10 @@
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: hsts-header
+  namespace: traefik
+spec:
+  headers:
+    stsIncludeSubdomains: true
+    stsSeconds: 63072000
+    stsPreload: true

--- a/oci/traefik/platform-aks/kustomization.yaml
+++ b/oci/traefik/platform-aks/kustomization.yaml
@@ -2,6 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../base
+  - hsts-middleware.yaml
+  - root-ingress-route.yaml
 patches:
   - target:
       kind: HelmRelease

--- a/oci/traefik/platform-aks/root-ingress-route.yaml
+++ b/oci/traefik/platform-aks/root-ingress-route.yaml
@@ -1,0 +1,15 @@
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: root-ingress-route
+  namespace: traefik
+spec:
+  entryPoints:
+    - http
+    - https
+  routes:
+    - kind: Rule
+      match: PathPrefix(`/`)
+      services:
+        - kind: TraefikService
+          name: noop@internal


### PR DESCRIPTION
Add HTTP Strict-Transport-Security (HSTS) middleware with 2-year max-age and root catch-all ingress route across adminservices, apps, eformidling-aks, and platform-aks overlays. The HSTS middleware is also deployed to the default namespace in the apps overlay.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added HSTS (HTTP Strict-Transport-Security) middleware configuration across all deployment environments with subdomain coverage and preload support.
  * Added root ingress route to handle all incoming traffic across HTTP and HTTPS entry points.
  * Updated deployment configurations to include the new middleware and routing rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->