### PR TITLE
feat(traefik): add helm.sh/resource-policy keep to extraObjects before removal

### DIFF
--- a/oci/traefik/adminservices/kustomization.yaml
+++ b/oci/traefik/adminservices/kustomization.yaml
@@ -16,3 +16,35 @@ patches:
         path: /spec/values/ports/https/http/middlewares
         value:
           - traefik-hsts-header@kubernetescrd
+      - op: add
+        path: /spec/values/extraObjects
+        value:
+          - apiVersion: traefik.io/v1alpha1
+            kind: Middleware
+            metadata:
+              name: hsts-header
+              namespace: traefik
+              annotations:
+                helm.sh/resource-policy: keep
+            spec:
+              headers:
+                stsIncludeSubdomains: true
+                stsSeconds: 63072000
+                stsPreload: true
+          - apiVersion: traefik.io/v1alpha1
+            kind: IngressRoute
+            metadata:
+              name: root-ingress-route
+              namespace: traefik
+              annotations:
+                helm.sh/resource-policy: keep
+            spec:
+              entryPoints:
+                - http
+                - https
+              routes:
+                - kind: Rule
+                  match: PathPrefix(`/`)
+                  services:
+                    - kind: TraefikService
+                      name: noop@internal

--- a/oci/traefik/apps/kustomization.yaml
+++ b/oci/traefik/apps/kustomization.yaml
@@ -14,3 +14,47 @@ patches:
         path: /spec/values/ports/https/http/middlewares
         value:
           - traefik-hsts-header@kubernetescrd
+      - op: add
+        path: /spec/values/extraObjects
+        value:
+          - apiVersion: traefik.io/v1alpha1
+            kind: Middleware
+            metadata:
+              name: hsts-header
+              namespace: traefik
+              annotations:
+                helm.sh/resource-policy: keep
+            spec:
+              headers:
+                stsIncludeSubdomains: true
+                stsSeconds: 63072000
+                stsPreload: true
+          - apiVersion: traefik.io/v1alpha1
+            kind: Middleware
+            metadata:
+              name: hsts-header
+              namespace: default
+              annotations:
+                helm.sh/resource-policy: keep
+            spec:
+              headers:
+                stsIncludeSubdomains: true
+                stsSeconds: 63072000
+                stsPreload: true
+          - apiVersion: traefik.io/v1alpha1
+            kind: IngressRoute
+            metadata:
+              name: root-ingress-route
+              namespace: traefik
+              annotations:
+                helm.sh/resource-policy: keep
+            spec:
+              entryPoints:
+                - http
+                - https
+              routes:
+                - kind: Rule
+                  match: PathPrefix(`/`)
+                  services:
+                    - kind: TraefikService
+                      name: noop@internal

--- a/oci/traefik/eformidling-aks/kustomization.yaml
+++ b/oci/traefik/eformidling-aks/kustomization.yaml
@@ -36,3 +36,35 @@ patches:
         value:
           - "${AKS_SYSTEM_SUBNET_CIDR}"
           - "${AKS_WORK_SUBNET_CIDR}"
+      - op: add
+        path: /spec/values/extraObjects
+        value:
+          - apiVersion: traefik.io/v1alpha1
+            kind: Middleware
+            metadata:
+              name: hsts-header
+              namespace: traefik
+              annotations:
+                helm.sh/resource-policy: keep
+            spec:
+              headers:
+                stsIncludeSubdomains: true
+                stsSeconds: 63072000
+                stsPreload: true
+          - apiVersion: traefik.io/v1alpha1
+            kind: IngressRoute
+            metadata:
+              name: root-ingress-route
+              namespace: traefik
+              annotations:
+                helm.sh/resource-policy: keep
+            spec:
+              entryPoints:
+                - http
+                - https
+              routes:
+                - kind: Rule
+                  match: PathPrefix(`/`)
+                  services:
+                    - kind: TraefikService
+                      name: noop@internal

--- a/oci/traefik/platform-aks/kustomization.yaml
+++ b/oci/traefik/platform-aks/kustomization.yaml
@@ -60,3 +60,35 @@ patches:
           - "${AKS_SYSTEM_SUBNET_CIDR}"
           - "${AKS_WORK_SUBNET_CIDR}"
           - "${AKS_FILESCAN_SUBNET_CIDR}"
+      - op: add
+        path: /spec/values/extraObjects
+        value:
+          - apiVersion: traefik.io/v1alpha1
+            kind: Middleware
+            metadata:
+              name: hsts-header
+              namespace: traefik
+              annotations:
+                helm.sh/resource-policy: keep
+            spec:
+              headers:
+                stsIncludeSubdomains: true
+                stsSeconds: 63072000
+                stsPreload: true
+          - apiVersion: traefik.io/v1alpha1
+            kind: IngressRoute
+            metadata:
+              name: root-ingress-route
+              namespace: traefik
+              annotations:
+                helm.sh/resource-policy: keep
+            spec:
+              entryPoints:
+                - http
+                - https
+              routes:
+                - kind: Rule
+                  match: PathPrefix(`/`)
+                  services:
+                    - kind: TraefikService
+                      name: noop@internal


### PR DESCRIPTION
## Summary

Adds `helm.sh/resource-policy: keep` to all `extraObjects` entries (Middleware and IngressRoute) across all overlays.

## Why

3.5.0 removed `extraObjects` but caused downtime on the test cluster: Helm deleted the resources during its upgrade before Flux re-applied the standalone manifests. The root cause is that Helm tracks and deletes resources it previously created via `extraObjects` when they are removed.

## Migration path

| Step | Release | What happens |
|------|---------|--------------|
| 1 | **3.6.0** (this PR) | Helm upgrades, stamps `helm.sh/resource-policy: keep` onto live resources — no deletion |
| 2 | **3.7.0** (follow-up PR) | Remove `extraObjects` patches — Helm sees `keep` annotation and skips deletion; Flux already owns the resources via standalone manifests |

## Deployment order

- **Remaining rings** (at_ring1, at_ring2, tt_ring1, prod_ring1): deploy **3.6.0 before 3.5.0** — or skip 3.5.0 entirely and go 3.4.0 → 3.6.0 → 3.7.0
- **Test cluster** (already at 3.5.0): deploy 3.6.0 — Helm will re-adopt the Flux-managed resources and add the `keep` annotation

## Affected packages

- `oci/traefik` — all overlays (`adminservices`, `apps`, `eformidling-aks`, `platform-aks`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configured HTTP Strict Transport Security (HSTS) headers across multiple environments.
  * Added root path ingress routing configuration to forward all traffic appropriately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->