### PR TITLE
feat(altinn-uptime): add Dialogporten health endpoint

### DIFF
--- a/oci/altinn-uptime/configmaps/extra-targets.yaml
+++ b/oci/altinn-uptime/configmaps/extra-targets.yaml
@@ -21,7 +21,6 @@ data:
         "https://at23.dis-core.altinn.cloud/whoami",
         "https://tt02.dis-core.altinn.cloud/whoami",
         "https://prod.dis-core.altinn.cloud/whoami",
-
         "https://discore-at23-m22d0r-apim.azure-api.net/dialogporten/health"
       ],
       "ipv6": [
@@ -58,8 +57,7 @@ data:
           "IPv4 and IPv6 arrays contain targets for regular blackbox jobs",
           "kuberneteswrapper_ipv4 and kuberneteswrapper_ipv6 arrays contain targets for kuberneteswrapper jobs",
           "tls_ipv4 and tls_ipv6 arrays contain targets that require TLS verification, but not 2xx",
-          "Targets are monitored using blackbox HTTP probes",
-          "Within each array, entries are grouped by product and separated by a blank line. Current groups: altinn-core, dialogporten"
+          "Targets are monitored using blackbox HTTP probes"
         ]
       }
     }

--- a/oci/altinn-uptime/configmaps/extra-targets.yaml
+++ b/oci/altinn-uptime/configmaps/extra-targets.yaml
@@ -20,7 +20,9 @@ data:
         "https://at22.dis-core.altinn.cloud/whoami",
         "https://at23.dis-core.altinn.cloud/whoami",
         "https://tt02.dis-core.altinn.cloud/whoami",
-        "https://prod.dis-core.altinn.cloud/whoami"
+        "https://prod.dis-core.altinn.cloud/whoami",
+
+        "https://discore-at23-m22d0r-apim.azure-api.net/dialogporten/health"
       ],
       "ipv6": [
         "https://altinncdn.no/orgs/altinn-orgs.json",
@@ -48,15 +50,16 @@ data:
       "metadata": {
         "description": "Extra targets for Altinn monitoring that are not auto-generated from organizations",
         "maintained_by": "Altinn Platform Team",
-        "last_updated": "2025-11-11",
-        "version": "1.0",
+        "last_updated": "2026-05-06",
+        "version": "1.1",
         "notes": [
           "These targets are manually maintained and will be preserved during automatic updates",
           "Organization targets are auto-generated and should not be added here",
           "IPv4 and IPv6 arrays contain targets for regular blackbox jobs",
           "kuberneteswrapper_ipv4 and kuberneteswrapper_ipv6 arrays contain targets for kuberneteswrapper jobs",
           "tls_ipv4 and tls_ipv6 arrays contain targets that require TLS verification, but not 2xx",
-          "Targets are monitored using blackbox HTTP probes"
+          "Targets are monitored using blackbox HTTP probes",
+          "Within each array, entries are grouped by product and separated by a blank line. Current groups: altinn-core, dialogporten"
         ]
       }
     }


### PR DESCRIPTION
## Summary

- Adds `https://discore-at23-m22d0r-apim.azure-api.net/dialogporten/health` to the `ipv4` extra targets so the blackbox exporter monitors the Dialogporten health endpoint via the standard `http_2xx` probe
- Introduces a per-product grouping convention inside the `extra-targets.json` arrays (blank-line separators, valid JSON whitespace) so altinn-core entries and product-specific entries are easy to distinguish — current groups: `altinn-core`, `dialogporten`
- Documents the new convention in `metadata.notes` and bumps `version` to `1.1` / `last_updated` to `2026-05-06`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration Updates**
  * Added additional monitoring targets to the uptime system to broaden health checks across services.
  * Updated configuration metadata (version and last_updated) to reflect the latest rollout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->