### PR TITLE
feat(blackbox-exporter): add http_health_check module

### DIFF
--- a/oci/blackbox-exporter/altinn-uptime/kustomization.yaml
+++ b/oci/blackbox-exporter/altinn-uptime/kustomization.yaml
@@ -182,7 +182,7 @@ patches:
                   method: GET
                   preferred_ip_protocol: ip4
                   ip_protocol_fallback: false
-                  fail_if_not_matches_regexp:
+                  fail_if_body_not_matches_regexp:
                     - '"status"\s*:\s*"Healthy"'
                   tls_config:
                     insecure_skip_verify: false
@@ -195,7 +195,7 @@ patches:
                   method: GET
                   preferred_ip_protocol: ip6
                   ip_protocol_fallback: false
-                  fail_if_not_matches_regexp:
+                  fail_if_body_not_matches_regexp:
                     - '"status"\s*:\s*"Healthy"'
                   tls_config:
                     insecure_skip_verify: false

--- a/oci/blackbox-exporter/altinn-uptime/kustomization.yaml
+++ b/oci/blackbox-exporter/altinn-uptime/kustomization.yaml
@@ -183,7 +183,7 @@ patches:
                   preferred_ip_protocol: ip4
                   ip_protocol_fallback: false
                   fail_if_body_not_matches_regexp:
-                    - '"status"\s*:\s*"Healthy"'
+                    - '^\{"status"\s*:\s*"Healthy"'
                   tls_config:
                     insecure_skip_verify: false
               http_health_check_ipv6:
@@ -196,6 +196,6 @@ patches:
                   preferred_ip_protocol: ip6
                   ip_protocol_fallback: false
                   fail_if_body_not_matches_regexp:
-                    - '"status"\s*:\s*"Healthy"'
+                    - '^\{"status"\s*:\s*"Healthy"'
                   tls_config:
                     insecure_skip_verify: false

--- a/oci/blackbox-exporter/altinn-uptime/kustomization.yaml
+++ b/oci/blackbox-exporter/altinn-uptime/kustomization.yaml
@@ -173,7 +173,7 @@ patches:
                     - 401
                     - 403
                     - 404
-              http_health_check:
+              http_health_check_ipv4:
                 prober: http
                 timeout: 10s
                 http:
@@ -181,6 +181,20 @@ patches:
                   valid_status_codes: [200]
                   method: GET
                   preferred_ip_protocol: ip4
+                  ip_protocol_fallback: false
+                  fail_if_not_matches_regexp:
+                    - '"status"\s*:\s*"Healthy"'
+                  tls_config:
+                    insecure_skip_verify: false
+              http_health_check_ipv6:
+                prober: http
+                timeout: 10s
+                http:
+                  valid_http_versions: ["HTTP/1.1", "HTTP/2.0"]
+                  valid_status_codes: [200]
+                  method: GET
+                  preferred_ip_protocol: ip6
+                  ip_protocol_fallback: false
                   fail_if_not_matches_regexp:
                     - '"status"\s*:\s*"Healthy"'
                   tls_config:

--- a/oci/blackbox-exporter/altinn-uptime/kustomization.yaml
+++ b/oci/blackbox-exporter/altinn-uptime/kustomization.yaml
@@ -173,3 +173,15 @@ patches:
                     - 401
                     - 403
                     - 404
+              http_health_check:
+                prober: http
+                timeout: 10s
+                http:
+                  valid_http_versions: ["HTTP/1.1", "HTTP/2.0"]
+                  valid_status_codes: [200]
+                  method: GET
+                  preferred_ip_protocol: ip4
+                  fail_if_not_matches_regexp:
+                    - '"status"\s*:\s*"Healthy"'
+                  tls_config:
+                    insecure_skip_verify: false


### PR DESCRIPTION
## Summary

- Adds a new `http_health_check` blackbox-exporter probe module to the `altinn-uptime` overlay
- The module performs an HTTP GET over IPv4 and verifies the response body contains a top-level `"status": "Healthy"` field via regex
- Accepts only HTTP 200 with valid TLS (no insecure skip), supporting HTTP/1.1 and HTTP/2

## Test plan

- [x] `kustomize build oci/blackbox-exporter/altinn-uptime` renders successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added IPv4 and IPv6 HTTP health probes that require HTTP 200 and a JSON `"status":"Healthy"` indicator; probes enforce secure TLS verification.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dis-way/gitops-manifests/pull/1020)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->