### PR TITLE
feat: Add kube-state-metrics OCI package

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -15,6 +15,7 @@
   "oci/grafana-operator": "2.1.4",
   "oci/headscale": "1.10.0",
   "oci/kro": "0.2.0",
+  "oci/kube-state-metrics": "1.0.0",
   "oci/kyverno-policies": "1.4.1",
   "oci/kyverno": "1.3.2",
   "oci/lakmus": "1.1.4",

--- a/oci/kube-state-metrics/CHANGELOG.md
+++ b/oci/kube-state-metrics/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Changelog

--- a/oci/kube-state-metrics/base/helmrelease.yaml
+++ b/oci/kube-state-metrics/base/helmrelease.yaml
@@ -1,0 +1,277 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: kube-state-metrics
+  namespace: kube-state-metrics
+spec:
+  chart:
+    spec:
+      chart: kube-state-metrics
+      sourceRef:
+        kind: HelmRepository
+        name: prometheus-community
+        namespace: kube-state-metrics
+      # renovate: datasource=helm registryUrl=https://prometheus-community.github.io/helm-charts packageName=kube-state-metrics
+      version: 7.3.0
+  interval: 1h
+  timeout: 5m
+  install:
+    remediation:
+      retries: 5
+  upgrade:
+    remediation:
+      retries: 5
+  targetNamespace: kube-state-metrics
+  releaseName: kube-state-metrics
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              kind: ServiceMonitor
+              group: monitoring.coreos.com
+            patch: |-
+              - op: replace
+                path: /apiVersion
+                value: azmonitoring.coreos.com/v1
+              - op: add
+                path: /spec/labelLimit
+                value: 63
+              - op: add
+                path: /spec/labelNameLengthLimit
+                value: 511
+              - op: add
+                path: /spec/labelValueLengthLimit
+                value: 1023
+  values:
+    image:
+      registry: altinncr.azurecr.io/registry.k8s.io
+    collectors: []
+    customResourceStateOnly: true
+    customResourceState:
+      enabled: true
+      config:
+        spec:
+          resources:
+            - groupVersionKind:
+                group: kustomize.toolkit.fluxcd.io
+                version: v1
+                kind: Kustomization
+              metricNamePrefix: gotk
+              metrics:
+                - name: resource_info
+                  help: "The current state of a Flux Kustomization resource."
+                  each:
+                    type: Info
+                    info:
+                      labelsFromPath:
+                        name: [metadata, name]
+                  labelsFromPath:
+                    exported_namespace: [metadata, namespace]
+                    ready: [status, conditions, "[type=Ready]", status]
+                    suspended: [spec, suspend]
+                    revision: [status, lastAppliedRevision]
+                    source_name: [spec, sourceRef, name]
+            - groupVersionKind:
+                group: helm.toolkit.fluxcd.io
+                version: v2
+                kind: HelmRelease
+              metricNamePrefix: gotk
+              metrics:
+                - name: resource_info
+                  help: "The current state of a Flux HelmRelease resource."
+                  each:
+                    type: Info
+                    info:
+                      labelsFromPath:
+                        name: [metadata, name]
+                  labelsFromPath:
+                    exported_namespace: [metadata, namespace]
+                    ready: [status, conditions, "[type=Ready]", status]
+                    suspended: [spec, suspend]
+                    revision: [status, history, "0", chartVersion]
+                    chart_name: [status, history, "0", chartName]
+                    chart_app_version: [status, history, "0", appVersion]
+                    chart_ref_name: [spec, chartRef, name]
+                    chart_source_name: [spec, chart, spec, sourceRef, name]
+            - groupVersionKind:
+                group: source.toolkit.fluxcd.io
+                version: v1
+                kind: GitRepository
+              metricNamePrefix: gotk
+              metrics:
+                - name: resource_info
+                  help: "The current state of a Flux GitRepository resource."
+                  each:
+                    type: Info
+                    info:
+                      labelsFromPath:
+                        name: [metadata, name]
+                  labelsFromPath:
+                    exported_namespace: [metadata, namespace]
+                    ready: [status, conditions, "[type=Ready]", status]
+                    suspended: [spec, suspend]
+                    revision: [status, artifact, revision]
+                    url: [spec, url]
+            - groupVersionKind:
+                group: source.toolkit.fluxcd.io
+                version: v1
+                kind: Bucket
+              metricNamePrefix: gotk
+              metrics:
+                - name: resource_info
+                  help: "The current state of a Flux Bucket resource."
+                  each:
+                    type: Info
+                    info:
+                      labelsFromPath:
+                        name: [metadata, name]
+                  labelsFromPath:
+                    exported_namespace: [metadata, namespace]
+                    ready: [status, conditions, "[type=Ready]", status]
+                    suspended: [spec, suspend]
+                    revision: [status, artifact, revision]
+                    endpoint: [spec, endpoint]
+                    bucket_name: [spec, bucketName]
+            - groupVersionKind:
+                group: source.toolkit.fluxcd.io
+                version: v1
+                kind: HelmRepository
+              metricNamePrefix: gotk
+              metrics:
+                - name: resource_info
+                  help: "The current state of a Flux HelmRepository resource."
+                  each:
+                    type: Info
+                    info:
+                      labelsFromPath:
+                        name: [metadata, name]
+                  labelsFromPath:
+                    exported_namespace: [metadata, namespace]
+                    ready: [status, conditions, "[type=Ready]", status]
+                    suspended: [spec, suspend]
+                    revision: [status, artifact, revision]
+                    url: [spec, url]
+            - groupVersionKind:
+                group: source.toolkit.fluxcd.io
+                version: v1
+                kind: HelmChart
+              metricNamePrefix: gotk
+              metrics:
+                - name: resource_info
+                  help: "The current state of a Flux HelmChart resource."
+                  each:
+                    type: Info
+                    info:
+                      labelsFromPath:
+                        name: [metadata, name]
+                  labelsFromPath:
+                    exported_namespace: [metadata, namespace]
+                    ready: [status, conditions, "[type=Ready]", status]
+                    suspended: [spec, suspend]
+                    revision: [status, artifact, revision]
+                    chart_name: [spec, chart]
+                    chart_version: [spec, version]
+            - groupVersionKind:
+                group: source.toolkit.fluxcd.io
+                version: v1
+                kind: OCIRepository
+              metricNamePrefix: gotk
+              metrics:
+                - name: resource_info
+                  help: "The current state of a Flux OCIRepository resource."
+                  each:
+                    type: Info
+                    info:
+                      labelsFromPath:
+                        name: [metadata, name]
+                  labelsFromPath:
+                    exported_namespace: [metadata, namespace]
+                    ready: [status, conditions, "[type=Ready]", status]
+                    suspended: [spec, suspend]
+                    revision: [status, artifact, revision]
+                    url: [spec, url]
+            - groupVersionKind:
+                group: notification.toolkit.fluxcd.io
+                version: v1beta3
+                kind: Alert
+              metricNamePrefix: gotk
+              metrics:
+                - name: resource_info
+                  help: "The current state of a Flux Alert resource."
+                  each:
+                    type: Info
+                    info:
+                      labelsFromPath:
+                        name: [metadata, name]
+                  labelsFromPath:
+                    exported_namespace: [metadata, namespace]
+                    suspended: [spec, suspend]
+            - groupVersionKind:
+                group: notification.toolkit.fluxcd.io
+                version: v1beta3
+                kind: Provider
+              metricNamePrefix: gotk
+              metrics:
+                - name: resource_info
+                  help: "The current state of a Flux Provider resource."
+                  each:
+                    type: Info
+                    info:
+                      labelsFromPath:
+                        name: [metadata, name]
+                  labelsFromPath:
+                    exported_namespace: [metadata, namespace]
+                    suspended: [spec, suspend]
+            - groupVersionKind:
+                group: notification.toolkit.fluxcd.io
+                version: v1
+                kind: Receiver
+              metricNamePrefix: gotk
+              metrics:
+                - name: resource_info
+                  help: "The current state of a Flux Receiver resource."
+                  each:
+                    type: Info
+                    info:
+                      labelsFromPath:
+                        name: [metadata, name]
+                  labelsFromPath:
+                    exported_namespace: [metadata, namespace]
+                    ready: [status, conditions, "[type=Ready]", status]
+                    suspended: [spec, suspend]
+                    webhook_path: [status, webhookPath]
+    rbac:
+      extraRules:
+        - apiGroups:
+            - source.toolkit.fluxcd.io
+            - kustomize.toolkit.fluxcd.io
+            - helm.toolkit.fluxcd.io
+            - notification.toolkit.fluxcd.io
+          resources:
+            - gitrepositories
+            - buckets
+            - helmrepositories
+            - helmcharts
+            - ocirepositories
+            - kustomizations
+            - helmreleases
+            - alerts
+            - providers
+            - receivers
+          verbs:
+            - list
+            - watch
+    prometheus:
+      monitor:
+        enabled: true
+    nodeSelector:
+      kubernetes.azure.com/mode: system
+    tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
+    resources:
+      requests:
+        cpu: 25m
+        memory: 64Mi
+      limits:
+        memory: 128Mi

--- a/oci/kube-state-metrics/base/helmrelease.yaml
+++ b/oci/kube-state-metrics/base/helmrelease.yaml
@@ -43,8 +43,6 @@ spec:
                 path: /spec/labelValueLengthLimit
                 value: 1023
   values:
-    image:
-      registry: altinncr.azurecr.io/registry.k8s.io
     collectors: []
     customResourceStateOnly: true
     customResourceState:

--- a/oci/kube-state-metrics/base/helmrepository.yaml
+++ b/oci/kube-state-metrics/base/helmrepository.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: prometheus-community
+  namespace: kube-state-metrics
+spec:
+  interval: 1h
+  url: https://prometheus-community.github.io/helm-charts

--- a/oci/kube-state-metrics/base/kustomization.yaml
+++ b/oci/kube-state-metrics/base/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - helmrepository.yaml
+  - helmrelease.yaml

--- a/oci/kube-state-metrics/base/namespace.yaml
+++ b/oci/kube-state-metrics/base/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kube-state-metrics

--- a/oci/kube-state-metrics/kustomization.yaml
+++ b/oci/kube-state-metrics/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - base

--- a/oci/releaseconfig.json
+++ b/oci/releaseconfig.json
@@ -119,6 +119,14 @@
     "prod_ring1": "0.2.0",
     "prod_ring2": "0.2.0"
   },
+  "kube-state-metrics": {
+    "at_ring1": "1.0.0",
+    "at_ring2": "1.0.0",
+    "tt_ring1": "1.0.0",
+    "tt_ring2": "1.0.0",
+    "prod_ring1": "1.0.0",
+    "prod_ring2": "1.0.0"
+  },
   "kyverno": {
     "at_ring1": "1.3.2",
     "at_ring2": "1.3.2",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -64,6 +64,10 @@
       "release-type": "simple",
       "component": "oci-kro"
     },
+    "oci/kube-state-metrics": {
+      "release-type": "simple",
+      "component": "oci-kube-state-metrics"
+    },
     "oci/kyverno": {
       "release-type": "simple",
       "component": "oci-kyverno"


### PR DESCRIPTION
Register kube-state-metrics in release-please configuration and releaseconfig.json with version 1.0.0 deployed across all rings. Includes Flux HelmRelease with custom resource state metrics for Flux resources (Kustomization, HelmRelease, GitRepository, etc.) and Azure Monitor ServiceMonitor patching.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added kube-state-metrics monitoring component (v1.0.0) deployed across all production and test environments with Prometheus integration enabled.
  * Configured custom resource state monitoring for Flux resources with extended metrics collection and RBAC permissions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dis-way/gitops-manifests/pull/1058?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->