### PR TITLE
feat: Add headplane package for headscale management UI

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -13,6 +13,7 @@
   "oci/dis-tls-cert": "2.8.0",
   "oci/external-secrets-operator": "1.6.6",
   "oci/grafana-operator": "2.1.4",
+  "oci/headplane": "1.0.0",
   "oci/headscale": "1.10.0",
   "oci/kro": "0.2.0",
   "oci/kube-state-metrics": "1.1.0",

--- a/oci/headplane/README.md
+++ b/oci/headplane/README.md
@@ -26,14 +26,14 @@ Two records are required in the `altinn.cloud` zone:
 
 1. **Service record** — points the hostname at the Traefik load balancer (same IP used by Traefik and headscale):
 
-```
+```text
 headplane.altinn.cloud  A     <PUBLIC_IP_V4>
 headplane.altinn.cloud  AAAA  <PUBLIC_IP_V6>
 ```
 
 2. **ACME delegation** — delegates the DNS-01 challenge to the Azure DNS zone managed by cert-manager:
 
-```
+```text
 _acme-challenge.headplane.altinn.cloud  CNAME  _acme-challenge.headplane.altinn.cloud.prod.admin.altinn.cloud
 ```
 

--- a/oci/headplane/README.md
+++ b/oci/headplane/README.md
@@ -1,0 +1,67 @@
+# Headplane
+
+Web UI for managing the headscale control server, authenticated via Microsoft Entra OIDC.
+
+## Variables
+
+| Variable | Default | Required | Description |
+|----------|---------|----------|-------------|
+| `HEADPLANE_APP_CLIENT_ID` | - | Yes | Microsoft Entra OIDC client ID for headplane |
+| `HEADPLANE_APP_CLIENT_SECRET` | - | Yes | Microsoft Entra OIDC client secret — source from a secret store, not plain substitution |
+| `HEADPLANE_COOKIE_SECRET` | - | Yes | Random secret used to sign headplane session cookies |
+| `HEADPLANE_API_KEY` | - | Yes | Headscale API key used by headplane to manage the control server |
+
+## Layers
+
+| Path | Description |
+|------|-------------|
+| `.` | Core resources: namespace, secret, deployment, service, gateway, and HTTPRoute |
+| `post-deploy` | cert-manager Certificate for Let's Encrypt TLS |
+
+## Prerequisites
+
+### DNS
+
+Two records are required in the `altinn.cloud` zone:
+
+1. **Service record** — points the hostname at the Traefik load balancer (same IP used by Traefik and headscale):
+
+```
+headplane.altinn.cloud  A     <PUBLIC_IP_V4>
+headplane.altinn.cloud  AAAA  <PUBLIC_IP_V6>
+```
+
+2. **ACME delegation** — delegates the DNS-01 challenge to the Azure DNS zone managed by cert-manager:
+
+```
+_acme-challenge.headplane.altinn.cloud  CNAME  _acme-challenge.headplane.altinn.cloud.prod.admin.altinn.cloud
+```
+
+The ACME delegation must be in place before deploying `post-deploy/`, as cert-manager uses DNS-01 via the delegated zone to issue the certificate from `letsencrypt-production`.
+
+Two Flux `Kustomization` resources are required: one for the main package and one for `post-deploy/`, which requests the TLS certificate. The `post-deploy` Kustomization sets `wait: false` so cert-manager can issue the certificate asynchronously without blocking health checks.
+
+```yaml
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: headplane
+spec:
+  path: .
+  postBuild:
+    substitute:
+      HEADPLANE_APP_CLIENT_ID: "00000000-0000-0000-0000-000000000000"
+      HEADPLANE_APP_CLIENT_SECRET: "secret"
+      HEADPLANE_COOKIE_SECRET: "random-32-char-string"
+      HEADPLANE_API_KEY: "hskey-api-..."
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: headplane-post-deploy
+spec:
+  path: ./post-deploy
+  wait: false
+  dependsOn:
+    - name: headplane
+```

--- a/oci/headplane/gateway.yaml
+++ b/oci/headplane/gateway.yaml
@@ -1,0 +1,18 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: headplane
+  namespace: headplane
+spec:
+  gatewayClassName: traefik
+  listeners:
+    - name: https
+      port: 8443
+      protocol: HTTPS
+      hostname: headplane.altinn.cloud
+      tls:
+        certificateRefs:
+          - name: headplane-tls
+      allowedRoutes:
+        namespaces:
+          from: Same

--- a/oci/headplane/headplane.yaml
+++ b/oci/headplane/headplane.yaml
@@ -26,7 +26,7 @@ spec:
       containers:
         - name: headplane
           # renovate: datasource=docker depName=tale/headplane registryUrl=https://ghcr.io
-          image: altinncr.azurecr.io/ghcr.io/tale/headplane:latest
+          image: altinncr.azurecr.io/ghcr.io/tale/headplane:0.6.3
           imagePullPolicy: Always
           ports:
             - name: http

--- a/oci/headplane/headplane.yaml
+++ b/oci/headplane/headplane.yaml
@@ -1,0 +1,77 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: headplane
+  namespace: headplane
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: headplane
+  template:
+    metadata:
+      labels:
+        app: headplane
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: headplane
+          # renovate: datasource=docker depName=tale/headplane registryUrl=https://ghcr.io
+          image: altinncr.azurecr.io/ghcr.io/tale/headplane:latest
+          imagePullPolicy: Always
+          ports:
+            - name: http
+              containerPort: 3000
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+          volumeMounts:
+            - name: config
+              mountPath: /etc/headplane/config.yaml
+              subPath: config.yaml
+              readOnly: true
+            - name: data
+              mountPath: /var/lib/headplane
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: config
+          secret:
+            secretName: headplane-config
+        - name: data
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: headplane
+  namespace: headplane
+spec:
+  selector:
+    app: headplane
+  ports:
+    - name: http
+      port: 3000
+      targetPort: http
+      protocol: TCP

--- a/oci/headplane/httproute.yaml
+++ b/oci/headplane/httproute.yaml
@@ -1,0 +1,30 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: headplane
+  namespace: headplane
+spec:
+  parentRefs:
+    - name: headplane
+      sectionName: https
+  hostnames:
+    - headplane.altinn.cloud
+  rules:
+    - matches:
+        - path:
+            type: Exact
+            value: /
+      filters:
+        - type: RequestRedirect
+          requestRedirect:
+            path:
+              type: ReplaceFullPath
+              replaceFullPath: /admin/
+            statusCode: 301
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: headplane
+          port: 3000

--- a/oci/headplane/kustomization.yaml
+++ b/oci/headplane/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - secret.yaml
+  - headplane.yaml
+  - gateway.yaml
+  - httproute.yaml

--- a/oci/headplane/namespace.yaml
+++ b/oci/headplane/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: headplane
+  annotations:
+    linkerd.io/inject: enabled

--- a/oci/headplane/post-deploy/certificate.yaml
+++ b/oci/headplane/post-deploy/certificate.yaml
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: headplane-tls
+  namespace: headplane
+spec:
+  secretName: headplane-tls
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+    - headplane.altinn.cloud

--- a/oci/headplane/post-deploy/kustomization.yaml
+++ b/oci/headplane/post-deploy/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - certificate.yaml

--- a/oci/headplane/secret.yaml
+++ b/oci/headplane/secret.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: headplane-config
+  namespace: headplane
+type: Opaque
+stringData:
+  config.yaml: |
+    server:
+      host: "0.0.0.0"
+      port: 3000
+      base_url: "https://headplane.altinn.cloud"
+      cookie_secret: "${HEADPLANE_COOKIE_SECRET}"
+      cookie_secure: true
+      data_path: "/var/lib/headplane"
+
+    headscale:
+      url: "http://headscale.headscale.svc.cluster.local.:8080"
+      api_key: "${HEADPLANE_API_KEY}"
+
+    oidc:
+      issuer: "https://login.microsoftonline.com/cd0026d8-283b-4a55-9bfa-d0ef4a8ba21c/v2.0"
+      client_id: "${HEADPLANE_APP_CLIENT_ID}"
+      client_secret: "${HEADPLANE_APP_CLIENT_SECRET}"
+      headscale_api_key: "${HEADPLANE_API_KEY}"
+      use_pkce: true
+      disable_api_key_login: true
+      profile_picture_source: "gravatar"

--- a/oci/releaseconfig.json
+++ b/oci/releaseconfig.json
@@ -199,6 +199,14 @@
     "prod_ring1": "0.7.1",
     "prod_ring2": "0.7.1"
   },
+  "headplane": {
+    "at_ring1": "1.0.0",
+    "at_ring2": "1.0.0",
+    "tt_ring1": "1.0.0",
+    "tt_ring2": "1.0.0",
+    "prod_ring1": "1.0.0",
+    "prod_ring2": "1.0.0"
+  },
   "headscale": {
     "at_ring1": "1.10.0",
     "at_ring2": "1.10.0",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -56,6 +56,10 @@
       "release-type": "simple",
       "component": "oci-grafana-operator"
     },
+    "oci/headplane": {
+      "release-type": "simple",
+      "component": "oci-headplane"
+    },
     "oci/headscale": {
       "release-type": "simple",
       "component": "oci-headscale"


### PR DESCRIPTION
Registers the new `oci/headplane` package with Release Please and adds deployment manifests for the Headplane web UI, including namespace, secret, deployment, service, gateway, HTTPRoute, and post-deploy certificate resources.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added headplane application—a Web UI for managing headscale with Microsoft Entra OIDC authentication support.

* **Chores**
  * Updated release configuration and manifests for the new headplane component deployment.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dis-way/gitops-manifests/pull/1067?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->