### PR TITLE
fix(kyverno): exclude kyverno namespace from Linkerd proxy injector webhook

### DIFF
--- a/oci/kyverno/base/namespace.yaml
+++ b/oci/kyverno/base/namespace.yaml
@@ -2,3 +2,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: kyverno
+  labels:
+    config.linkerd.io/admission-webhooks: disabled


### PR DESCRIPTION
## Summary

- Adds `config.linkerd.io/admission-webhooks: disabled` label to the `kyverno` namespace
- Prevents a bootstrap deadlock on fresh cluster deployments where Kyverno and Linkerd block each other from starting

## Root cause

Linkerd's proxy injector webhook is configured with `failurePolicy: Fail` (HA mode) and uses `config.linkerd.io/admission-webhooks: disabled` as its namespace exclusion key. The `kyverno` namespace had none of the labels that Linkerd uses to exclude namespaces, so Linkerd's webhook intercepted Kyverno pod admission.

On a fresh cluster, when Linkerd is installing and its webhook is registered but not yet serving, Kyverno pods cannot start — and without Kyverno, Linkerd's own policy validation is also affected. The result is a deadlock that requires manual intervention to resolve.

The other direction (Kyverno blocking Linkerd) is already handled: `linkerd` is in Kyverno's `webhooks.namespaceSelector` exclusion list in `oci/kyverno/base/helmrelease.yaml`.

## Affected packages

- `oci/kyverno`

## Test plan

- [ ] Verify `kustomize build oci/kyverno/base` renders the namespace with the label
- [ ] Deploy to a fresh cluster and confirm Kyverno and Linkerd come up without manual intervention

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated kyverno namespace configuration to disable Linkerd admission webhooks for improved namespace isolation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dis-way/gitops-manifests/pull/1119?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->