### PR TITLE
deps: update dis-pgsql-operator docker tag to v0.8.1

### DIFF
--- a/oci/dis-pgsql/base/flux-kustomize.yaml
+++ b/oci/dis-pgsql/base/flux-kustomize.yaml
@@ -22,7 +22,7 @@ spec:
     - name: controller
       newName: altinncr.azurecr.io/ghcr.io/altinn/altinn-platform/dis-pgsql-operator
       # renovate: datasource=docker depName=ghcr.io/altinn/altinn-platform/dis-pgsql-operator versioning=semver
-      newTag: v0.8.0
+      newTag: v0.8.1
   sourceRef:
     kind: OCIRepository
     name: dis-pgsql-operator

--- a/oci/dis-pgsql/base/oci-repository.yaml
+++ b/oci/dis-pgsql/base/oci-repository.yaml
@@ -8,6 +8,6 @@ spec:
   provider: azure
   ref:
     # renovate: datasource=docker depName=ghcr.io/altinn/altinn-platform/dis-pgsql-operator versioning=semver
-    tag: v0.8.0
+    tag: v0.8.1
   timeout: 5m0s
   url: oci://altinncr.azurecr.io/dis/kustomize/dis-pgsql-operator


### PR DESCRIPTION
## Summary
- Bump `dis-pgsql-operator` Docker image tag from `v0.8.0` to `v0.8.1` in the `oci/dis-pgsql` package.
- Updates both the `OCIRepository` ref tag and the Flux Kustomization image `newTag`.

This will trigger Release Please to cut a new `oci/dis-pgsql` package release (patch bump from `0.1.7`).

## Affected packages
- `oci/dis-pgsql`

## Test plan
- [x] `kustomize build oci/dis-pgsql` renders successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dis-pgsql operator and controller components to v0.8.1

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dis-way/gitops-manifests/pull/1131?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->