### PR TITLE
deps: update dis-pgsql-operator docker tag to v0.8.2

### DIFF
--- a/oci/dis-pgsql/base/flux-kustomize.yaml
+++ b/oci/dis-pgsql/base/flux-kustomize.yaml
@@ -22,7 +22,7 @@ spec:
     - name: controller
       newName: altinncr.azurecr.io/ghcr.io/altinn/altinn-platform/dis-pgsql-operator
       # renovate: datasource=docker depName=ghcr.io/altinn/altinn-platform/dis-pgsql-operator versioning=semver
-      newTag: v0.8.1
+      newTag: v0.8.2
   sourceRef:
     kind: OCIRepository
     name: dis-pgsql-operator

--- a/oci/dis-pgsql/base/oci-repository.yaml
+++ b/oci/dis-pgsql/base/oci-repository.yaml
@@ -8,6 +8,6 @@ spec:
   provider: azure
   ref:
     # renovate: datasource=docker depName=ghcr.io/altinn/altinn-platform/dis-pgsql-operator versioning=semver
-    tag: v0.8.1
+    tag: v0.8.2
   timeout: 5m0s
   url: oci://altinncr.azurecr.io/dis/kustomize/dis-pgsql-operator


### PR DESCRIPTION
## Summary
- Bump `dis-pgsql-operator` image from `v0.8.1` → `v0.8.2`.

Affected package: `oci/dis-pgsql`
- `oci/dis-pgsql/base/oci-repository.yaml` — `tag: v0.8.2`
- `oci/dis-pgsql/base/flux-kustomize.yaml` — `newTag: v0.8.2`

v0.8.2 includes the fix for AAD principal creation running against the `postgres` maintenance database (resolves the `pgaadauth_create_principal_with_oid` 42883 error that left `Database` resources stuck at `AccessReady=False`).

## Test plan
- [x] `kustomize build oci/dis-pgsql` succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dis-pgsql-operator from version 0.8.1 to 0.8.2.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dis-way/gitops-manifests/pull/1137?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->