### PR TITLE
feat(kube-state-metrics): Add multitenancy overlay

### DIFF
--- a/oci/kube-state-metrics/README.md
+++ b/oci/kube-state-metrics/README.md
@@ -1,0 +1,14 @@
+# kube-state-metrics
+
+Deploys kube-state-metrics configured to expose Flux CD resource status as custom metrics.
+
+## Variables
+
+No variables.
+
+## Layers
+
+| Path | Description |
+|------|-------------|
+| `base` | Deploys kube-state-metrics into the `kube-state-metrics` namespace with custom resource state metrics for all Flux resource types |
+| `multitenancy` | Relocates the HelmRepository and HelmRelease into `platform-system` for multitenant clusters where `flux-applier` runs in that namespace |

--- a/oci/kube-state-metrics/multitenancy/kustomization.yaml
+++ b/oci/kube-state-metrics/multitenancy/kustomization.yaml
@@ -1,0 +1,20 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base
+patches:
+  - target:
+      kind: HelmRepository
+    patch: |
+      - op: replace
+        path: /metadata/namespace
+        value: platform-system
+  - target:
+      kind: HelmRelease
+    patch: |
+      - op: replace
+        path: /metadata/namespace
+        value: platform-system
+      - op: replace
+        path: /spec/chart/spec/sourceRef/namespace
+        value: platform-system


### PR DESCRIPTION
Adds a multitenancy overlay that deploys kube-state-metrics to the `platform-system` namespace by patching the HelmRepository and HelmRelease resources.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated infrastructure configuration to consolidate platform system components within a dedicated namespace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->