### PR TITLE
feat(platform-system): add dis-console-reader ClusterRole for cross-namespace Flux reads

### DIFF
--- a/oci/platform-system/dis-console-reader.yaml
+++ b/oci/platform-system/dis-console-reader.yaml
@@ -1,0 +1,44 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: dis-console-reader
+rules:
+  - apiGroups:
+      - kustomize.toolkit.fluxcd.io
+    resources:
+      - kustomizations
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - helm.toolkit.fluxcd.io
+    resources:
+      - helmreleases
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+    resources:
+      - ocirepositories
+      - helmrepositories
+      - helmcharts
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: dis-console-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: dis-console-reader
+subjects:
+  - kind: ServiceAccount
+    name: dis-console
+    namespace: product-dis

--- a/oci/platform-system/kustomization.yaml
+++ b/oci/platform-system/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 resources:
   - namespace.yaml
   - clusterrolebinding.yaml
+  - dis-console-reader.yaml


### PR DESCRIPTION
## What

Adds a cluster-scoped `ClusterRole` + `ClusterRoleBinding` (`dis-console-reader`) to the `platform-system` artifact, granting the `dis-console` ServiceAccount (namespace `product-dis`) `get`/`list`/`watch` on the Flux custom resources, across **all namespaces**:

- `kustomizations.kustomize.toolkit.fluxcd.io`
- `helmreleases.helm.toolkit.fluxcd.io`
- `ocirepositories` / `helmrepositories` / `helmcharts` `.source.toolkit.fluxcd.io`

## Why

`dis-console` (`services/dis-console` in `Altinn/altinn-platform`) reads Flux CRs across all namespaces and serves their deployment status as a JSON API. It runs as a Deployment in `product-dis`, deployed by the **namespace-scoped** product-dis syncroot applier.

That applier is `scope: namespace`, and Azure RBAC forbids it from creating cluster-scoped objects, so applying this RBAC from the product syncroot fails:

> clusterroles.rbac.authorization.k8s.io "dis-console-reader" is forbidden: User "system:serviceaccount:product-dis:flux-applier" cannot patch resource "clusterroles" in API group "rbac.authorization.k8s.io" at the cluster scope

Cluster-scoped RBAC has to come from the **cluster-privileged `platform-system` applier** (the same one whose `flux-applier` holds `cluster-admin` and carries the operators' ClusterRoles) — which is what this PR does. The product-dis syncroot is updated separately to drop these two objects.

## Safety (platform-wide is fine)

The binding targets the `dis-console` ServiceAccount in `product-dis`. On any cluster where that SA does not exist yet (no dis-console workload), the binding is **inert** — it grants nothing until the SA appears. So shipping this ahead of, and broader than, the workload is safe.

## Rollout

On merge, release-please proposes a release for `oci-platform-system`; merging that publishes the artifact and opens a **"Gitops OCI image promotion"** issue. dis-console currently targets **at22 (`at_ring1`)** and **at23 (`at_ring2`)** — promote `at_ring1` first to validate on at22, then `at_ring2`, then the remaining rings as dis-console expands.

## Verification

`kustomize build oci/platform-system` succeeds and emits the `dis-console-reader` ClusterRole + ClusterRoleBinding alongside the existing platform-system resources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)