### PR TITLE
docs: Refactor grafana-operator and restructure into base/overlay

### DIFF
--- a/oci/grafana-operator/README.md
+++ b/oci/grafana-operator/README.md
@@ -1,55 +1,27 @@
 # Grafana Operator
 
-## Description
+Deploys the Grafana Operator via Helm and connects it to an external Azure Managed Grafana instance.
 
-This directory contains the Flux configuration for deploying the Grafana Operator using Helm and configuring an external Grafana instance.
+## Variables
 
-## Deployment Image
+| Variable | Default | Required | Description |
+|----------|---------|----------|-------------|
+| `GRAFANA_ADMIN_APIKEY` | — | Yes | Admin API key for the external Grafana instance |
+| `EXTERNAL_GRAFANA_URL` | — | Yes | Full URL of the external Azure Managed Grafana instance |
+| `K8S_DNS_NAME` | — | Yes | Cluster DNS hostname used in the `/monitor` redirect IngressRoute |
+| `REDIRECT_GRAFANA_FROM_FQDN` | — | Yes | Legacy Grafana FQDN to redirect from (no protocol, `fqdn-to-azure-grafana` only) |
+| `REDIRECT_GRAFANA_TO_FQDN` | — | Yes | Target Azure Managed Grafana FQDN to redirect to (no protocol, `fqdn-to-azure-grafana` only) |
 
-The deployment uses the following image:
-- **Repository**: `altinncr.azurecr.io/ghcr.io/grafana/grafana-operator`
-- **Original Source**: `ghcr.io/grafana/grafana-operator`
+## Layers
 
-The image is pulled from Altinn's Azure Container Registry (altinncr.azurecr.io) which mirrors the official Grafana Operator image from GitHub Container Registry.
-
-## Configuration
-
-### Required Environment Variables
-
-The following environment variables must be set for proper deployment:
-
-| Variable | Description | Example |
-|----------|-------------|---------|
-| `EXTERNAL_GRAFANA_URL` | URL of the external Grafana instance | `https://grafana.example.com` |
-| `GRAFANA_ADMIN_APIKEY` | Admin API key for Grafana authentication | `glsa_xxxxxxxxxxxxxxxxxxxx` |
-
-### Components
-
-1. **Namespace**: Creates `grafana` namespace with Linkerd injection enabled
-2. **Helm Repository**: Configures Grafana Helm repository source
-3. **Helm Release**: Deploys the Grafana Operator with custom configuration
-4. **External Grafana**: Configures connection to external Grafana instance
-5. **API Key Secret**: Stores Grafana admin API key securely
-
-### Features Enabled
-
-- **Service Monitor**: Prometheus monitoring enabled with custom label limits
-- **Dashboard Management**: Automatic dashboard provisioning enabled
-- **Custom Patches**: ServiceMonitor patches for Azure Monitor compatibility
-
-### Resource Customizations
-
-The deployment includes post-render patches that:
-- Update ServiceMonitor API version to `azmonitoring.coreos.com/v1`
-- Set label limits: 63 labels max, 511 char name limit, 1023 char value limit
-- Enable CRD management with create/replace strategy
-
-### Security
-
-- API keys are stored as Kubernetes secrets
-- External Grafana connection uses secure API key authentication
-- Namespace has Linkerd service mesh injection enabled
-
-## Usage
-
-Ensure environment variables are properly substituted in your Flux configuration before deployment.
+| Path | Description |
+|------|-------------|
+| `base` | Namespace, HelmRepository, HelmRelease (grafana-operator), and `grafana-admin-apikey` Secret |
+| `adminservices` | Overlay for the admin services cluster; references `base` |
+| `adminservices/post-deploy` | External Grafana CR and Traefik `/monitor` redirect; depends on `adminservices` |
+| `dis` | Overlay for the DIS cluster; references `base` |
+| `post-deploy` | `Grafana` CR connecting to the external Azure Managed Grafana instance |
+| `grafana-redirect` | Traefik `IngressRoute` and `Middleware` redirecting `/monitor` traffic to Azure Grafana |
+| `grafana-manifests/base` | `GrafanaDashboard` CRs: blackbox exporter, public IP, Traefik, FluxCD, and Linkerd dashboards |
+| `grafana-manifests/apps` | Overlay adding the Altinn pod console error log dashboard |
+| `fqdn-to-azure-grafana` | Traefik redirect from a legacy Grafana FQDN to Azure Managed Grafana (HTTP 301, path-preserving) |

--- a/oci/grafana-operator/adminservices/kustomization.yaml
+++ b/oci/grafana-operator/adminservices/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base

--- a/oci/grafana-operator/adminservices/post-deploy/kustomization.yaml
+++ b/oci/grafana-operator/adminservices/post-deploy/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../post-deploy
+  - ../../grafana-redirect

--- a/oci/grafana-operator/base/grafana-admin-apikey.yaml
+++ b/oci/grafana-operator/base/grafana-admin-apikey.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: grafana-admin-apikey
+  namespace: grafana
+type: Opaque
+stringData:
+  GF_SECURITY_APIKEY: "${GRAFANA_ADMIN_APIKEY}"

--- a/oci/grafana-operator/base/helmrelease.yaml
+++ b/oci/grafana-operator/base/helmrelease.yaml
@@ -1,0 +1,61 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: grafana-operator
+  namespace: grafana
+spec:
+  chart:
+    spec:
+      chart: grafana-operator
+      reconcileStrategy: ChartVersion
+      sourceRef:
+        kind: HelmRepository
+        name: grafana
+        namespace: grafana
+      # renovate: datasource=helm registryUrl=https://grafana.github.io/helm-charts packageName=grafana-operator
+      version: 5.23.0
+  interval: 1h
+  timeout: 5m
+  install:
+    crds: CreateReplace
+    remediation:
+      retries: 5
+  upgrade:
+    crds: CreateReplace
+    remediation:
+      retries: 5
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              kind: ServiceMonitor
+            patch: |
+              - op: replace
+                path: /apiVersion
+                value: azmonitoring.coreos.com/v1
+              - op: add
+                path: /spec/labelLimit
+                value: 63
+              - op: add
+                path: /spec/labelNameLengthLimit
+                value: 511
+              - op: add
+                path: /spec/labelValueLengthLimit
+                value: 1023
+  values:
+    podAnnotations: 
+      cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+    image:
+      registry: altinncr.azurecr.io
+      repository: ghcr.io/grafana/grafana-operator
+    serviceMonitor:
+      enabled: true
+    dashboard:
+      enabled: true
+    tolerations:
+      - key: "CriticalAddonsOnly"
+        operator: "Exists"
+        effect: "NoSchedule"
+    nodeSelector:
+      kubernetes.azure.com/mode: system
+      kubernetes.azure.com/agentpool: syspool    

--- a/oci/grafana-operator/base/helmrepository.yaml
+++ b/oci/grafana-operator/base/helmrepository.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: grafana
+  namespace: grafana
+spec:
+  interval: 1h
+  url: https://grafana.github.io/helm-charts

--- a/oci/grafana-operator/base/kustomization.yaml
+++ b/oci/grafana-operator/base/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - grafana-admin-apikey.yaml
+  - helmrepository.yaml
+  - helmrelease.yaml

--- a/oci/grafana-operator/base/namespace.yaml
+++ b/oci/grafana-operator/base/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: grafana

--- a/oci/grafana-operator/kustomization.yaml
+++ b/oci/grafana-operator/kustomization.yaml
@@ -1,7 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - namespace.yaml
-  - grafana-admin-apikey.yaml
-  - helmrepository.yaml
-  - helmrelease.yaml
+  - base


### PR DESCRIPTION
- Simplify README to follow project standard format with Variables and Layers sections
- Reorganize manifests into `base/` for shared resources and overlays for cluster-specific configs
- Add `adminservices/` and `dis/` overlays with `post-deploy/` subdirectories for layered deployments
- Extract `grafana-admin-apikey` Secret and Helm configuration into base layer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Grafana Operator deployment configuration using Helm with Azure Managed Grafana support and layered Kustomize setup for flexible deployments.

* **Documentation**
  * Rewrote README with deployment variables and configuration layer documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->