### PR TITLE
deps: update dis-pgsql-operator to v0.10.0

### DIFF
--- a/oci/dis-pgsql/base/flux-kustomize.yaml
+++ b/oci/dis-pgsql/base/flux-kustomize.yaml
@@ -22,7 +22,7 @@ spec:
     - name: controller
       newName: altinncr.azurecr.io/ghcr.io/altinn/altinn-platform/dis-pgsql-operator
       # renovate: datasource=docker depName=ghcr.io/altinn/altinn-platform/dis-pgsql-operator versioning=semver
-      newTag: v0.9.0
+      newTag: v0.10.0
   sourceRef:
     kind: OCIRepository
     name: dis-pgsql-operator

--- a/oci/dis-pgsql/base/oci-repository.yaml
+++ b/oci/dis-pgsql/base/oci-repository.yaml
@@ -8,6 +8,6 @@ spec:
   provider: azure
   ref:
     # renovate: datasource=docker depName=ghcr.io/altinn/altinn-platform/dis-pgsql-operator versioning=semver
-    tag: v0.9.0
+    tag: v0.10.0
   timeout: 5m0s
   url: oci://altinncr.azurecr.io/dis/kustomize/dis-pgsql-operator


### PR DESCRIPTION
Manual bump (Renovate hasn't picked it up yet) of the dis-pgsql-operator image and kustomize artifact from v0.9.0 to v0.10.0.

Affected package: `oci/dis-pgsql` (image `newTag` + OCIRepository `ref.tag`).

[dis-pgsql v0.10.0](https://github.com/Altinn/altinn-platform/releases/tag/dis-pgsql-v0.10.0) ships one feature: direct service-principal access grants (`servicePrincipal` in the Database CR, Altinn/altinn-platform#3676) — needed in the admin clusters for the per-tenant workflow-engine databases.

`kustomize build oci/dis-pgsql` validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated PostgreSQL operator to version 0.10.0 in deployment configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->