### PR TITLE
fix: Add wildcard DNS name to altinn.studio certificate

### DIFF
--- a/oci/dis-tls-cert/certs/altinn.studio.yaml
+++ b/oci/dis-tls-cert/certs/altinn.studio.yaml
@@ -10,3 +10,4 @@ spec:
     kind: ClusterIssuer
   dnsNames:
     - altinn.studio
+    - "*.altinn.studio"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated TLS certificate configuration to extend SSL/TLS coverage to all subdomains of altinn.studio through wildcard domain support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->