### PR TITLE
feat(linkerd): Add timeout configuration to proxy probes

### DIFF
--- a/oci/linkerd/base/helmrelease.yaml
+++ b/oci/linkerd/base/helmrelease.yaml
@@ -96,6 +96,10 @@ spec:
       image:
         name: altinncr.azurecr.io/ghcr.io/linkerd/proxy
       defaultInboundPolicy: "${DEFAULT_INBOUND_POLICY:=all-unauthenticated}"
+      livenessProbe:
+        timeoutSeconds: 10
+      readinessProbe:
+        timeoutSeconds: 10
     podMonitor:
       enabled: true
       scrapeInterval: 60s


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Linkerd control-plane health probe configuration to include 10-second timeout settings for liveness and readiness checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->