### PR TITLE
chore: Use Cloudflare API for IP list updates

### DIFF
--- a/.github/workflows/update-cloudflare-ips.yml
+++ b/.github/workflows/update-cloudflare-ips.yml
@@ -21,11 +21,10 @@ jobs:
         id: update
         run: |
           python3 - <<'EOF'
-          import urllib.request, re
+          import urllib.request, re, json
 
-          v4 = urllib.request.urlopen('https://www.cloudflare.com/ips-v4').read().decode().strip().splitlines()
-          v6 = urllib.request.urlopen('https://www.cloudflare.com/ips-v6').read().decode().strip().splitlines()
-          new_ips = v4 + v6
+          data = json.loads(urllib.request.urlopen('https://api.cloudflare.com/client/v4/ips').read())
+          new_ips = data['result']['ipv4_cidrs'] + data['result']['ipv6_cidrs']
 
           path = 'oci/traefik/multitenancy/lb-source-ranges-configmap.yaml'
           with open(path) as f:


### PR DESCRIPTION
Replace separate IPv4 and IPv6 endpoint calls with the official Cloudflare API endpoint, reducing HTTP requests and improving reliability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Optimized the automated IP range update workflow to fetch Cloudflare IPv4 and IPv6 CIDR ranges from the official API endpoint, replacing web scraping with a more reliable and maintainable approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->