### PR TITLE
chore(traefik): force push IP range updates and skip duplicate PRs

### DIFF
--- a/.github/workflows/update-cloudflare-ips.yml
+++ b/.github/workflows/update-cloudflare-ips.yml
@@ -59,7 +59,8 @@ jobs:
           git checkout -b "$BRANCH"
           git add oci/traefik/multitenancy/lb-source-ranges-configmap.yaml
           git commit -m "chore(traefik): update Cloudflare IP ranges"
-          git push origin "$BRANCH"
+          git push --force origin "$BRANCH"
+          gh pr list --head "$BRANCH" --json number --jq '.[0].number' | grep -q . || \
           gh pr create \
             --title "chore(traefik): update Cloudflare IP ranges" \
             --body "Automated update of Cloudflare IP ranges in the traefik load balancer source ranges ConfigMap." \


### PR DESCRIPTION
When updating Cloudflare IP ranges, use `--force` to overwrite the branch if a PR already exists, and check for existing PRs before creating a new one to avoid duplicates.