### PR TITLE
fix(grafana-operator): deploy grafana-manifests to adminservices

### DIFF
--- a/oci/grafana-operator/adminservices/post-deploy/kustomization.yaml
+++ b/oci/grafana-operator/adminservices/post-deploy/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 resources:
   - ../../post-deploy
   - ../../grafana-redirect
+  - ../../grafana-manifests/apps


### PR DESCRIPTION
## Problem

The grafana **operator** is installed on the adminservices cluster, but the grafana **content** (dashboards, folders, alert rules) never deploys.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
