### PR TITLE
chore(traefik): automate Cloudflare IP update via GitHub API

### DIFF
--- a/.github/workflows/update-cloudflare-ips.yml
+++ b/.github/workflows/update-cloudflare-ips.yml
@@ -64,7 +64,7 @@ jobs:
           gh api "repos/$GITHUB_REPOSITORY/git/refs" \
             -f ref="refs/heads/$BRANCH" -f sha="$HEAD_SHA" 2>/dev/null || \
           gh api "repos/$GITHUB_REPOSITORY/git/refs/heads/$BRANCH" \
-            -X PATCH -f sha="$HEAD_SHA" -f force=true
+            -X PATCH -f sha="$HEAD_SHA" -F force=true
 
           # Commit via the Contents API — GitHub signs these commits automatically
           CONTENT_B64=$(base64 -w0 < "$FILE")

--- a/.github/workflows/update-cloudflare-ips.yml
+++ b/.github/workflows/update-cloudflare-ips.yml
@@ -53,13 +53,28 @@ jobs:
       - name: Open pull request
         if: steps.update.outputs.changed == 'true'
         run: |
+          FILE="oci/traefik/multitenancy/lb-source-ranges-configmap.yaml"
           BRANCH="chore/update-cloudflare-ips-$(date +%Y%m%d)"
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git checkout -b "$BRANCH"
-          git add oci/traefik/multitenancy/lb-source-ranges-configmap.yaml
-          git commit -m "chore(traefik): update Cloudflare IP ranges"
-          git push --force origin "$BRANCH"
+
+          # Blob SHA of the file on the current branch — required by the Contents API
+          FILE_SHA=$(gh api "repos/$GITHUB_REPOSITORY/contents/$FILE" --jq '.sha')
+
+          # Create or force-reset the branch to the current HEAD (main)
+          HEAD_SHA=$(git rev-parse HEAD)
+          gh api "repos/$GITHUB_REPOSITORY/git/refs" \
+            -f ref="refs/heads/$BRANCH" -f sha="$HEAD_SHA" 2>/dev/null || \
+          gh api "repos/$GITHUB_REPOSITORY/git/refs/heads/$BRANCH" \
+            -X PATCH -f sha="$HEAD_SHA" -f force=true
+
+          # Commit via the Contents API — GitHub signs these commits automatically
+          CONTENT_B64=$(base64 -w0 < "$FILE")
+          gh api "repos/$GITHUB_REPOSITORY/contents/$FILE" \
+            -X PUT \
+            -f message="chore(traefik): update Cloudflare IP ranges" \
+            -f content="$CONTENT_B64" \
+            -f branch="$BRANCH" \
+            -f sha="$FILE_SHA"
+
           gh pr list --head "$BRANCH" --json number --jq '.[0].number' | grep -q . || \
           gh pr create \
             --title "chore(traefik): update Cloudflare IP ranges" \


### PR DESCRIPTION
Replace local git operations with the GitHub Contents API for committing and pushing the updated IP ranges file. This allows GitHub to automatically sign commits with the `github-actions[bot]` account, improving auditability and compliance with branch protection rules that require signed commits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the automated Cloudflare IP ranges update workflow to use a more reliable API-based approach for branch and file management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->