### PR TITLE
feat(grafana-operator): track grafana-content main tag instead of release

### DIFF
--- a/oci/grafana-operator/grafana-manifests/README.md
+++ b/oci/grafana-operator/grafana-manifests/README.md
@@ -22,19 +22,19 @@ grafana-manifests/
 Grafana folders, dashboards, and product alerts are delivered by the external
 [`altinn-dashboards-grafana`](https://github.com/Altinn/altinn-dashboards-grafana)
 Flux OCI artifact, published to `oci://altinncr.azurecr.io/monitoring/grafana`
-and pinned to `tag: release`.
+and pinned to `tag: main`.
 
 This package applies that artifact via two Flux objects in `base/`:
 
 - **`oci-repository.yaml`** — an `OCIRepository` named `grafana-content` that
-  pulls `oci://altinncr.azurecr.io/monitoring/grafana:release` (Azure provider).
+  pulls `oci://altinncr.azurecr.io/monitoring/grafana:main` (Azure provider).
 - **`flux-kustomize.yaml`** — a `Kustomization` named `grafana-content` that
   reconciles the artifact's repo-root kustomization (dashboards as
   self-contained `configMapRef` CRs, the platform folders, and all product
   alerts) into the `grafana` namespace with `prune: true`.
 
 Dashboards, folders, and alerts are added or changed in the
-`altinn-dashboards-grafana` repository — not here. Promote `main` → `release`
+`altinn-dashboards-grafana` repository — not here. Merge changes to `main`
 there to roll out new content.
 
 ## Usage

--- a/oci/grafana-operator/grafana-manifests/base/oci-repository.yaml
+++ b/oci/grafana-operator/grafana-manifests/base/oci-repository.yaml
@@ -7,6 +7,6 @@ spec:
   interval: 5m0s
   provider: azure
   ref:
-    tag: release
+    tag: main
   timeout: 5m0s
   url: oci://altinncr.azurecr.io/monitoring/grafana


### PR DESCRIPTION
## Summary

Switches the `grafana-content` OCIRepository to track the `main` tag instead of `release`, so it pulls the latest dashboards/content from `oci://altinncr.azurecr.io/monitoring/grafana`.

## Affected packages

- `oci/grafana-operator` — `grafana-manifests/base/oci-repository.yaml` (`ref.tag: release` → `main`)

## Validation

- `kustomize build oci/grafana-operator/grafana-manifests/base` renders cleanly; the `grafana-content` OCIRepository resolves to `tag: main`.

No changes to `oci/releaseconfig.json` or Release Please config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Grafana operator deployment configuration to track an alternative image source for content delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->