### PR TITLE
feat(traefik): Add ExternalSecret for TLS cert/key from Azure Key Vault

### DIFF
--- a/oci/traefik/README.md
+++ b/oci/traefik/README.md
@@ -26,6 +26,10 @@ CRDs (Traefik and Gateway API standard channel) are managed directly by the Helm
 | `AKS_POD_IPV6_CIDR` | `fd10:59f0:8c79:240::/64` | No (policies only) | AKS pod network IPv6 CIDR for Linkerd NetworkAuthentication |
 | `UAMI_CERT_MANAGER_CLIENT_ID` | — | platform-aks / eformidling-aks post-deploy | Managed identity client ID for cert-manager DNS-01 solver |
 | `CERT_DNS_NAME` | — | platform-aks / eformidling-aks post-deploy | Full DNS name for the TLS certificate (e.g. `internal.platform.prod.altinn.cloud`) |
+| `KV_SECRET_NAME_CERT` | — | apps post-deploy | Key Vault secret name holding the TLS certificate, pulled into `tls.crt` of the `ssl-cert` secret |
+| `KV_SECRET_NAME_KEY` | — | apps post-deploy | Key Vault secret name holding the TLS private key, pulled into `tls.key` of the `ssl-cert` secret |
+| `CERT_KV_UAMI_CLIENT_ID` | — | apps post-deploy | Managed identity client ID (federated to the `dis-tls-cert-kv-uami` SA in `traefik`) with read access to the `dis-tls-cert` Key Vault |
+| `CERT_KV_TENANT_ID` | `cd0026d8-283b-4a55-9bfa-d0ef4a8ba21c` | No | Azure tenant ID for the `dis-tls-cert-kv-uami` workload identity |
 
 ## Layers
 
@@ -41,6 +45,6 @@ CRDs (Traefik and Gateway API standard channel) are managed directly by the Helm
 | `post-deploy` | Shared post-deploy layer; HSTS `Middleware` and root catch-all `IngressRoute` (Traefik CRD resources applied after HelmRelease) |
 | `platform-aks/post-deploy` | Extends `post-deploy`; adds cert-manager `ClusterIssuer` (Let's Encrypt DNS-01 via Azure DNS) and `Certificate` for TLS |
 | `eformidling-aks/post-deploy` | Extends `post-deploy`; adds cert-manager `ClusterIssuer` (Let's Encrypt DNS-01 via Azure DNS) and `Certificate` for TLS |
-| `apps/post-deploy` | Extends `post-deploy`; adds `hsts-header` Middleware in the `default` namespace |
+| `apps/post-deploy` | Extends `post-deploy`; adds `hsts-header` Middleware in the `default` namespace and an `ssl-cert` ExternalSecret (with SecretStore + workload-identity SA) that pulls the TLS cert/key from the `dis-tls-cert` Azure Key Vault into a `kubernetes.io/tls` secret in the `traefik` namespace |
 | `adminservices/post-deploy` | Extends `post-deploy` |
 | `multitenancy/post-deploy` | Empty placeholder |

--- a/oci/traefik/apps/post-deploy/kustomization.yaml
+++ b/oci/traefik/apps/post-deploy/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 resources:
   - ../../post-deploy
   - hsts-middleware-default.yaml
+  - ssl-cert-external-secret.yaml

--- a/oci/traefik/apps/post-deploy/ssl-cert-external-secret.yaml
+++ b/oci/traefik/apps/post-deploy/ssl-cert-external-secret.yaml
@@ -1,0 +1,50 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: dis-tls-cert-kv-uami
+  namespace: traefik
+  annotations:
+    azure.workload.identity/client-id: ${CERT_KV_UAMI_CLIENT_ID}
+    azure.workload.identity/tenant-id: ${CERT_KV_TENANT_ID:=cd0026d8-283b-4a55-9bfa-d0ef4a8ba21c}
+  labels:
+    azure.workload.identity/use: "true"
+---
+apiVersion: external-secrets.io/v1
+kind: SecretStore
+metadata:
+  name: dis-tls-cert-store
+  namespace: traefik
+spec:
+  provider:
+    azurekv:
+      authType: WorkloadIdentity
+      vaultUrl: "https://dis-tls-cert.vault.azure.net"
+      serviceAccountRef:
+        name: dis-tls-cert-kv-uami
+        namespace: traefik
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: ssl-cert
+  namespace: traefik
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: SecretStore
+    name: dis-tls-cert-store
+  target:
+    name: ssl-cert
+    creationPolicy: Owner
+    template:
+      type: kubernetes.io/tls
+      data:
+        tls.crt: '{{ .crt }}'
+        tls.key: '{{ .key }}'
+  data:
+    - secretKey: crt
+      remoteRef:
+        key: ${KV_SECRET_NAME_CERT}
+    - secretKey: key
+      remoteRef:
+        key: ${KV_SECRET_NAME_KEY}


### PR DESCRIPTION
Add `apps/post-deploy` layer resources to pull TLS certificate and private
key from the `dis-tls-cert` Key Vault using workload identity. Includes ServiceAccount, SecretStore, and ExternalSecret configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for syncing TLS certificate and key data from Azure Key Vault into the Traefik namespace as a Kubernetes TLS secret.
  * Added workload identity-based secret access setup for the certificate sync flow.

* **Documentation**
  * Updated Traefik setup docs to include the new certificate-related configuration values and deployment details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->