### PR TITLE
feat(traefik): Add migration job to convert legacy ssl-cert secret type

### DIFF
--- a/oci/traefik/README.md
+++ b/oci/traefik/README.md
@@ -42,9 +42,9 @@ CRDs (Traefik and Gateway API standard channel) are managed directly by the Helm
 | `multitenancy` | Gateway API variant; Flux resources in `platform-system`, `kubernetesCRD` disabled, four Gateway listeners (http/https + wildcard), Linkerd policies included. Restricts `loadBalancerSourceRanges` to Cloudflare, altinn-uptime, and APIM via a ConfigMap (`valuesFrom`); Cloudflare ranges are updated automatically by the `update-cloudflare-ips` workflow. **No central HSTS** — `kubernetesCRD` is disabled so `Middleware` CRDs cannot be resolved; HSTS must be applied via `ResponseHeaderModifier` filters on individual `HTTPRoute` resources in downstream apps |
 | `eformidling-aks` | eFormidling AKS overlay; IPv4 single-stack, adds `loadBalancerSourceRanges` (APIM IP), and HSTS middleware |
 | `policies` | Linkerd `Server`, `NetworkAuthentication`, and `AuthorizationPolicy` resources for kubelet probes and proxy admin in deny-all mesh environments; see [`policies/README.md`](policies/README.md) |
-| `post-deploy` | Shared post-deploy layer; HSTS `Middleware` and root catch-all `IngressRoute` (Traefik CRD resources applied after HelmRelease) |
-| `platform-aks/post-deploy` | Extends `post-deploy`; adds cert-manager `ClusterIssuer` (Let's Encrypt DNS-01 via Azure DNS) and `Certificate` for TLS |
-| `eformidling-aks/post-deploy` | Extends `post-deploy`; adds cert-manager `ClusterIssuer` (Let's Encrypt DNS-01 via Azure DNS) and `Certificate` for TLS |
-| `apps/post-deploy` | Extends `post-deploy`; adds `hsts-header` Middleware in the `default` namespace and an `ssl-cert` ExternalSecret (with SecretStore + workload-identity SA) that pulls the TLS cert/key from the `dis-tls-cert` Azure Key Vault into a `kubernetes.io/tls` secret in the `traefik` namespace |
-| `adminservices/post-deploy` | Extends `post-deploy` |
-| `multitenancy/post-deploy` | Empty placeholder |
+| `post-deploy` | Manifests applied after the deployment has reconciled |
+| `platform-aks/post-deploy` | Manifests applied after the deployment has reconciled |
+| `eformidling-aks/post-deploy` | Manifests applied after the deployment has reconciled |
+| `apps/post-deploy` | Manifests applied after the deployment has reconciled |
+| `adminservices/post-deploy` | Manifests applied after the deployment has reconciled |
+| `multitenancy/post-deploy` | Manifests applied after the deployment has reconciled |

--- a/oci/traefik/apps/post-deploy/kustomization.yaml
+++ b/oci/traefik/apps/post-deploy/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
   - ../../post-deploy
   - hsts-middleware-default.yaml
   - ssl-cert-external-secret.yaml
+  - ssl-cert-migrate-job.yaml

--- a/oci/traefik/apps/post-deploy/ssl-cert-migrate-job.yaml
+++ b/oci/traefik/apps/post-deploy/ssl-cert-migrate-job.yaml
@@ -1,0 +1,105 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ssl-cert-migrate
+  namespace: traefik
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: ssl-cert-migrate
+  namespace: traefik
+rules:
+  # Inspect and remove the legacy Opaque secret so ESO can recreate it as kubernetes.io/tls
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: ["ssl-cert"]
+    verbs: ["get", "delete"]
+  # Trigger an immediate ExternalSecret resync instead of waiting for the refresh interval
+  - apiGroups: ["external-secrets.io"]
+    resources: ["externalsecrets"]
+    resourceNames: ["ssl-cert"]
+    verbs: ["get", "patch"]
+  # Wait until the SecretStore is Ready before deleting the live secret (watch can't use resourceNames)
+  - apiGroups: ["external-secrets.io"]
+    resources: ["secretstores"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ssl-cert-migrate
+  namespace: traefik
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ssl-cert-migrate
+subjects:
+  - kind: ServiceAccount
+    name: ssl-cert-migrate
+    namespace: traefik
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ssl-cert-migrate
+  namespace: traefik
+  annotations:
+    # Let Flux recreate the (immutable) Job whenever this manifest changes; safe because it is idempotent
+    kustomize.toolkit.fluxcd.io/force: enabled
+spec:
+  backoffLimit: 6
+  ttlSecondsAfterFinished: 600
+  template:
+    spec:
+      serviceAccountName: ssl-cert-migrate
+      restartPolicy: OnFailure
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1001
+        runAsGroup: 1001
+        fsGroup: 1001
+      containers:
+        - name: migrate
+          image: altinncr.azurecr.io/docker.io/bitnami/kubectl:latest
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1001
+            runAsGroup: 1001
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -eu
+              # Belt-and-suspenders: only touch the live secret once ESO can actually
+              # repopulate it. If the store never goes Ready the job fails and retries,
+              # leaving the existing secret intact -> no serving gap.
+              echo "Waiting for SecretStore dis-tls-cert-store to become Ready..."
+              kubectl wait --for=condition=Ready secretstore/dis-tls-cert-store \
+                -n traefik --timeout=120s
+
+              # A Secret's type is immutable, so an existing Opaque ssl-cert blocks ESO
+              # from owning it as kubernetes.io/tls. Delete it and force an immediate resync.
+              type=$(kubectl get secret ssl-cert -n traefik -o jsonpath='{.type}' 2>/dev/null || echo "")
+              if [ "$type" = "Opaque" ]; then
+                echo "Legacy Opaque ssl-cert found; deleting so ESO recreates it as kubernetes.io/tls"
+                kubectl delete secret ssl-cert -n traefik
+                kubectl annotate externalsecret ssl-cert -n traefik \
+                  force-sync="$(date +%s)" --overwrite
+                echo "Triggered ExternalSecret resync"
+              else
+                echo "ssl-cert type is '${type}' (not Opaque) - nothing to do"
+              fi


### PR DESCRIPTION
Adds a post-deploy Job that migrates the existing Opaque `ssl-cert` secret to `kubernetes.io/tls` type so ExternalSecret can manage it properly. The Job waits for the SecretStore to be Ready before deleting the legacy secret, ensuring no serving gap during the transition.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an automated post-deploy step to migrate the TLS certificate secret to the newer managed format.
  * The process safely checks readiness before updating and only acts when migration is needed.

* **Documentation**
  * Clarified post-deploy deployment notes so related manifests are described consistently as being applied after reconciliation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->