### PR TITLE
deps: update dis pgsql image tags to v0.11.0

### DIFF
--- a/oci/dis-pgsql/base/flux-kustomize.yaml
+++ b/oci/dis-pgsql/base/flux-kustomize.yaml
@@ -22,7 +22,7 @@ spec:
     - name: controller
       newName: altinncr.azurecr.io/ghcr.io/altinn/altinn-platform/dis-pgsql-operator
       # renovate: datasource=docker depName=ghcr.io/altinn/altinn-platform/dis-pgsql-operator versioning=semver
-      newTag: v0.10.0
+      newTag: v0.11.0
   sourceRef:
     kind: OCIRepository
     name: dis-pgsql-operator

--- a/oci/dis-pgsql/base/oci-repository.yaml
+++ b/oci/dis-pgsql/base/oci-repository.yaml
@@ -8,6 +8,6 @@ spec:
   provider: azure
   ref:
     # renovate: datasource=docker depName=ghcr.io/altinn/altinn-platform/dis-pgsql-operator versioning=semver
-    tag: v0.10.0
+    tag: v0.11.0
   timeout: 5m0s
   url: oci://altinncr.azurecr.io/dis/kustomize/dis-pgsql-operator


### PR DESCRIPTION
Bump `dis-pgsql-operator` from `v0.10.0` → `v0.11.0` in `oci/dis-pgsql/base/` (OCIRepository `ref.tag` + Kustomization `images[].newTag`).

`v0.11.0` ([release notes](https://github.com/Altinn/altinn-platform/releases/tag/dis-pgsql-v0.11.0)) brings:
- **fix:** decouple Private DNS zone CR name from Azure FQDN ([#3769](https://github.com/Altinn/altinn-platform/pull/3769)) — the reason for this bump; unblocks long server names (workflow-engine on ttd at23).
- feat: suffix Flexible Server AzureName with `--cluster-id` ([#3758](https://github.com/Altinn/altinn-platform/pull/3758)) — existing servers keep their AzureName; only new servers get the suffix.
- fix: bump golang.org/x/crypto + x/net for HIGH CVEs ([#3760](https://github.com/Altinn/altinn-platform/pull/3760)).

Merging cuts a new `oci-dis-pgsql` artifact and promotes the AT rings in `oci/releaseconfig.json` (admin-test canary first).

Validated with `kustomize build oci/dis-pgsql`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the `dis-pgsql-operator` deployment to use version `v0.11.0`.
  * Aligned the associated repository reference to the same version for consistent updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->