### PR TITLE
deps: update dis pgsql image tags to v0.11.1

### DIFF
--- a/oci/dis-pgsql/base/flux-kustomize.yaml
+++ b/oci/dis-pgsql/base/flux-kustomize.yaml
@@ -23,7 +23,7 @@ spec:
     - name: controller
       newName: altinncr.azurecr.io/ghcr.io/altinn/altinn-platform/dis-pgsql-operator
       # renovate: datasource=docker depName=ghcr.io/altinn/altinn-platform/dis-pgsql-operator versioning=semver
-      newTag: v0.11.0
+      newTag: v0.11.1
   sourceRef:
     kind: OCIRepository
     name: dis-pgsql-operator

--- a/oci/dis-pgsql/base/oci-repository.yaml
+++ b/oci/dis-pgsql/base/oci-repository.yaml
@@ -8,6 +8,6 @@ spec:
   provider: azure
   ref:
     # renovate: datasource=docker depName=ghcr.io/altinn/altinn-platform/dis-pgsql-operator versioning=semver
-    tag: v0.11.0
+    tag: v0.11.1
   timeout: 5m0s
   url: oci://altinncr.azurecr.io/dis/kustomize/dis-pgsql-operator


### PR DESCRIPTION
Bump `dis-pgsql-operator` `v0.11.0` → `v0.11.1` in `oci/dis-pgsql/base/` (OCIRepository `ref.tag` + Kustomization `images[].newTag`).

`v0.11.1` ([release](https://github.com/Altinn/altinn-platform/releases/tag/dis-pgsql-v0.11.1)) is a single fix:
- **fix:** grant `Owner` `CREATE` on its database ([#3772](https://github.com/Altinn/altinn-platform/pull/3772)) — lets apps that manage their own schema (e.g. workflow-engine's `CREATE SCHEMA engine`) run migrations, fixing `42501 permission denied for database`. The access job re-applies the grant to existing databases on reconcile.

Merging cuts a new `oci-dis-pgsql` artifact + promotes the AT rings in `oci/releaseconfig.json`. Validated with `kustomize build oci/dis-pgsql`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the deployed PostgreSQL operator image to a newer version.
  * Flux-managed deployment references now point to version `v0.11.1` instead of `v0.11.0`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->