### PR TITLE
feat(dis-tls-cert): Add data.altinn.no certificate and PushSecret

### DIFF
--- a/oci/dis-tls-cert/certs/data.altinn.no-push.yaml
+++ b/oci/dis-tls-cert/certs/data.altinn.no-push.yaml
@@ -1,0 +1,35 @@
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  name: data-altinn-no-push
+  namespace: dis-tls-cert
+spec:
+  refreshInterval: 1h
+  secretStoreRefs:
+    - name: dis-tls-cert-store
+      kind: SecretStore
+  selector:
+    secret:
+      name: data-altinn-no
+  template:
+    engineVersion: v2
+    type: kubernetes.io/tls
+    data:
+      tls.crt: '{{ index . "tls.crt" }}'
+      tls.key: '{{ index . "tls.key" }}'
+      pfx_bundle: '{{ fullPemToPkcs12 (index . "tls.crt") (index . "tls.key") | b64dec }}'
+  data:
+    # PEM format for Kubernetes clusters
+    - match:
+        secretKey: tls.crt
+        remoteRef:
+          remoteKey: data-altinn-no-crt
+    - match:
+        secretKey: tls.key
+        remoteRef:
+          remoteKey: data-altinn-no-key
+    # PFX format for Azure services
+    - match:
+        secretKey: pfx_bundle
+        remoteRef:
+          remoteKey: cert/data-altinn-no

--- a/oci/dis-tls-cert/certs/data.altinn.no.yaml
+++ b/oci/dis-tls-cert/certs/data.altinn.no.yaml
@@ -1,0 +1,13 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: data-altinn-no
+  namespace: dis-tls-cert
+spec:
+  secretName: data-altinn-no
+  issuerRef:
+    name: digicert-dis-tls-cert
+    kind: ClusterIssuer
+  dnsNames:
+    - data.altinn.no
+    - "*.data.altinn.no"

--- a/oci/dis-tls-cert/certs/kustomization.yaml
+++ b/oci/dis-tls-cert/certs/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - data.altinn.no.yaml
+  - data.altinn.no-push.yaml
   - altinn.studio.yaml
   - altinn.studio-push.yaml
   - ttd.apps.yt01.altinn.cloud.yaml


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for issuing and managing TLS certificates for `data.altinn.no` and its wildcard subdomains.
  * Added automated secret syncing for the certificate, including TLS key, certificate, and bundled PKCS#12 output.
  * Configured the certificate and related secret resources to be included in the deployment set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->