### PR TITLE
feat(altinn-uptime): add health check probes for dialogporten and info.at22

### DIFF
--- a/oci/altinn-uptime/configmaps/extra-targets.yaml
+++ b/oci/altinn-uptime/configmaps/extra-targets.yaml
@@ -20,8 +20,7 @@ data:
         "https://at22.dis-core.altinn.cloud/whoami",
         "https://at23.dis-core.altinn.cloud/whoami",
         "https://tt02.dis-core.altinn.cloud/whoami",
-        "https://prod.dis-core.altinn.cloud/whoami",
-        "https://discore-at23-m22d0r-apim.azure-api.net/dialogporten/health"
+        "https://prod.dis-core.altinn.cloud/whoami"
       ],
       "ipv6": [
         "https://altinncdn.no/orgs/altinn-orgs.json",
@@ -46,17 +45,23 @@ data:
         "https://altinn.no",
         "https://grafana.altinn.cloud"
       ],
+      "health_check_ipv4": [
+        "https://discore-at23-m22d0r-apim.azure-api.net/dialogporten/health",
+        "https://info.at22.altinn.cloud/health"
+      ],
+      "health_check_ipv6": [],
       "metadata": {
         "description": "Extra targets for Altinn monitoring that are not auto-generated from organizations",
         "maintained_by": "Altinn Platform Team",
-        "last_updated": "2026-05-06",
-        "version": "1.1",
+        "last_updated": "2026-07-02",
+        "version": "1.2",
         "notes": [
           "These targets are manually maintained and will be preserved during automatic updates",
           "Organization targets are auto-generated and should not be added here",
           "IPv4 and IPv6 arrays contain targets for regular blackbox jobs",
           "kuberneteswrapper_ipv4 and kuberneteswrapper_ipv6 arrays contain targets for kuberneteswrapper jobs",
           "tls_ipv4 and tls_ipv6 arrays contain targets that require TLS verification, but not 2xx",
+          "health_check_ipv4 and health_check_ipv6 arrays contain targets that must return 200 with a JSON body reporting status Healthy",
           "Targets are monitored using blackbox HTTP probes"
         ]
       }

--- a/oci/altinn-uptime/scripts/generate_targets.sh
+++ b/oci/altinn-uptime/scripts/generate_targets.sh
@@ -306,7 +306,7 @@ generate_expected_names() {
                 hostname=$(echo "$target" | sed -E 's|https?://([^/]+).*|\1|')
                 name=$(echo "$hostname" | sed 's/[^a-zA-Z0-9-]/-/g' | tr '[:upper:]' '[:lower:]')
                 # Ensure name doesn't exceed k8s limits (253 chars total)
-                max_name_len=$((253 - ${#UNIQUE_ID} - 40))  # Reserve space for prefix/suffix
+                max_name_len=$((253 - ${#UNIQUE_ID} - 43))  # Reserve space for prefix/suffix
                 if [ ${#name} -gt $max_name_len ]; then
                     name="${name:0:$max_name_len}"
                 fi
@@ -321,7 +321,7 @@ generate_expected_names() {
                 hostname=$(echo "$target" | sed -E 's|https?://([^/]+).*|\1|')
                 name=$(echo "$hostname" | sed 's/[^a-zA-Z0-9-]/-/g' | tr '[:upper:]' '[:lower:]')
                 # Ensure name doesn't exceed k8s limits (253 chars total)
-                max_name_len=$((253 - ${#UNIQUE_ID} - 40))  # Reserve space for prefix/suffix
+                max_name_len=$((253 - ${#UNIQUE_ID} - 43))  # Reserve space for prefix/suffix
                 if [ ${#name} -gt $max_name_len ]; then
                     name="${name:0:$max_name_len}"
                 fi
@@ -1068,7 +1068,7 @@ EOF
                 hostname=$(echo "$target" | sed -E 's|https?://([^/]+).*|\1|')
                 name=$(echo "$hostname" | sed 's/[^a-zA-Z0-9-]/-/g' | tr '[:upper:]' '[:lower:]')
                 # Ensure name doesn't exceed k8s limits (253 chars total)
-                max_name_len=$((253 - ${#UNIQUE_ID} - 40))  # Reserve space for prefix/suffix
+                max_name_len=$((253 - ${#UNIQUE_ID} - 43))  # Reserve space for prefix/suffix
                 if [ ${#name} -gt $max_name_len ]; then
                     name="${name:0:$max_name_len}"
                 fi
@@ -1140,7 +1140,7 @@ EOF
                 hostname=$(echo "$target" | sed -E 's|https?://([^/]+).*|\1|')
                 name=$(echo "$hostname" | sed 's/[^a-zA-Z0-9-]/-/g' | tr '[:upper:]' '[:lower:]')
                 # Ensure name doesn't exceed k8s limits (253 chars total)
-                max_name_len=$((253 - ${#UNIQUE_ID} - 40))  # Reserve space for prefix/suffix
+                max_name_len=$((253 - ${#UNIQUE_ID} - 43))  # Reserve space for prefix/suffix
                 if [ ${#name} -gt $max_name_len ]; then
                     name="${name:0:$max_name_len}"
                 fi

--- a/oci/altinn-uptime/scripts/generate_targets.sh
+++ b/oci/altinn-uptime/scripts/generate_targets.sh
@@ -298,6 +298,36 @@ generate_expected_names() {
                 expected_names="$expected_names blackbox-exporter-${UNIQUE_ID}-extra-${name}-tls-ipv6"
             fi
         done
+
+        # Process health check IPv4 extra targets
+        HEALTH_CHECK_IPV4_TARGETS=$(echo "$EXTRA_TARGETS_JSON" | jq -r '.health_check_ipv4[]?' 2>/dev/null)
+        for target in $HEALTH_CHECK_IPV4_TARGETS; do
+            if ! echo "$MAINTENANCE_IPV4" | grep -q "^$target$"; then
+                hostname=$(echo "$target" | sed -E 's|https?://([^/]+).*|\1|')
+                name=$(echo "$hostname" | sed 's/[^a-zA-Z0-9-]/-/g' | tr '[:upper:]' '[:lower:]')
+                # Ensure name doesn't exceed k8s limits (253 chars total)
+                max_name_len=$((253 - ${#UNIQUE_ID} - 40))  # Reserve space for prefix/suffix
+                if [ ${#name} -gt $max_name_len ]; then
+                    name="${name:0:$max_name_len}"
+                fi
+                expected_names="$expected_names blackbox-exporter-${UNIQUE_ID}-extra-${name}-health-check-ipv4"
+            fi
+        done
+
+        # Process health check IPv6 extra targets
+        HEALTH_CHECK_IPV6_TARGETS=$(echo "$EXTRA_TARGETS_JSON" | jq -r '.health_check_ipv6[]?' 2>/dev/null)
+        for target in $HEALTH_CHECK_IPV6_TARGETS; do
+            if ! echo "$MAINTENANCE_IPV6" | grep -q "^$target$"; then
+                hostname=$(echo "$target" | sed -E 's|https?://([^/]+).*|\1|')
+                name=$(echo "$hostname" | sed 's/[^a-zA-Z0-9-]/-/g' | tr '[:upper:]' '[:lower:]')
+                # Ensure name doesn't exceed k8s limits (253 chars total)
+                max_name_len=$((253 - ${#UNIQUE_ID} - 40))  # Reserve space for prefix/suffix
+                if [ ${#name} -gt $max_name_len ]; then
+                    name="${name:0:$max_name_len}"
+                fi
+                expected_names="$expected_names blackbox-exporter-${UNIQUE_ID}-extra-${name}-health-check-ipv6"
+            fi
+        done
     fi
 
     echo "$expected_names" | tr ' ' '\n' | grep -v '^$' | sort
@@ -1019,6 +1049,150 @@ spec:
     port: http
     scheme: http
   jobLabel: blackbox-http-ipv6-tls
+  namespaceSelector:
+    matchNames:
+    - $NAMESPACE
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: prometheus-blackbox-exporter
+      app.kubernetes.io/name: prometheus-blackbox-exporter
+EOF
+                apply_servicemonitor "$(cat "$TEMP_DIR/servicemonitor.yaml")" "$sm_name"
+            fi
+        done
+
+        # Health check IPv4 extra targets
+        HEALTH_CHECK_IPV4_TARGETS=$(echo "$EXTRA_TARGETS_JSON" | jq -r '.health_check_ipv4[]?' 2>/dev/null)
+        for target in $HEALTH_CHECK_IPV4_TARGETS; do
+            if ! echo "$MAINTENANCE_IPV4" | grep -q "^$target$"; then
+                hostname=$(echo "$target" | sed -E 's|https?://([^/]+).*|\1|')
+                name=$(echo "$hostname" | sed 's/[^a-zA-Z0-9-]/-/g' | tr '[:upper:]' '[:lower:]')
+                # Ensure name doesn't exceed k8s limits (253 chars total)
+                max_name_len=$((253 - ${#UNIQUE_ID} - 40))  # Reserve space for prefix/suffix
+                if [ ${#name} -gt $max_name_len ]; then
+                    name="${name:0:$max_name_len}"
+                fi
+                sm_name="blackbox-exporter-${UNIQUE_ID}-extra-${name}-health-check-ipv4"
+
+                cat > "$TEMP_DIR/servicemonitor.yaml" << EOF
+---
+apiVersion: azmonitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: $sm_name
+  namespace: $NAMESPACE
+  labels:
+    app: prometheus-blackbox-exporter
+    release: monitor
+    app.kubernetes.io/name: altinn-uptime
+    app.kubernetes.io/managed-by: altinn-uptime-sync
+    app.kubernetes.io/component: monitoring
+    altinn.no/environment: extra
+    altinn.no/organization: extra
+spec:
+  labelLimit: 63
+  labelNameLengthLimit: 511
+  labelValueLengthLimit: 1023
+  endpoints:
+  - honorTimestamps: true
+    interval: 15s
+    scrapeTimeout: 15s
+    metricRelabelings:
+    - action: replace
+      replacement: blackbox-http-ipv4-health-check
+      targetLabel: job
+    - action: replace
+      replacement: $hostname
+      targetLabel: instance
+    - action: replace
+      replacement: extra-${name}-health-check
+      sourceLabels:
+      - target
+      targetLabel: target
+    - action: replace
+      replacement: v4
+      targetLabel: ip_family
+    params:
+      module:
+      - http_health_check_ipv4
+      target:
+      - $target
+    path: /probe
+    port: http
+    scheme: http
+  jobLabel: blackbox-http-ipv4-health-check
+  namespaceSelector:
+    matchNames:
+    - $NAMESPACE
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: prometheus-blackbox-exporter
+      app.kubernetes.io/name: prometheus-blackbox-exporter
+EOF
+                apply_servicemonitor "$(cat "$TEMP_DIR/servicemonitor.yaml")" "$sm_name"
+            fi
+        done
+
+        # Health check IPv6 extra targets
+        HEALTH_CHECK_IPV6_TARGETS=$(echo "$EXTRA_TARGETS_JSON" | jq -r '.health_check_ipv6[]?' 2>/dev/null)
+        for target in $HEALTH_CHECK_IPV6_TARGETS; do
+            if ! echo "$MAINTENANCE_IPV6" | grep -q "^$target$"; then
+                hostname=$(echo "$target" | sed -E 's|https?://([^/]+).*|\1|')
+                name=$(echo "$hostname" | sed 's/[^a-zA-Z0-9-]/-/g' | tr '[:upper:]' '[:lower:]')
+                # Ensure name doesn't exceed k8s limits (253 chars total)
+                max_name_len=$((253 - ${#UNIQUE_ID} - 40))  # Reserve space for prefix/suffix
+                if [ ${#name} -gt $max_name_len ]; then
+                    name="${name:0:$max_name_len}"
+                fi
+                sm_name="blackbox-exporter-${UNIQUE_ID}-extra-${name}-health-check-ipv6"
+
+                cat > "$TEMP_DIR/servicemonitor.yaml" << EOF
+---
+apiVersion: azmonitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: $sm_name
+  namespace: $NAMESPACE
+  labels:
+    app: prometheus-blackbox-exporter
+    release: monitor
+    app.kubernetes.io/name: altinn-uptime
+    app.kubernetes.io/managed-by: altinn-uptime-sync
+    app.kubernetes.io/component: monitoring
+    altinn.no/environment: extra
+    altinn.no/organization: extra
+spec:
+  labelLimit: 63
+  labelNameLengthLimit: 511
+  labelValueLengthLimit: 1023
+  endpoints:
+  - honorTimestamps: true
+    interval: 15s
+    scrapeTimeout: 15s
+    metricRelabelings:
+    - action: replace
+      replacement: blackbox-http-ipv6-health-check
+      targetLabel: job
+    - action: replace
+      replacement: $hostname
+      targetLabel: instance
+    - action: replace
+      replacement: extra-${name}-health-check
+      sourceLabels:
+      - target
+      targetLabel: target
+    - action: replace
+      replacement: v6
+      targetLabel: ip_family
+    params:
+      module:
+      - http_health_check_ipv6
+      target:
+      - $target
+    path: /probe
+    port: http
+    scheme: http
+  jobLabel: blackbox-http-ipv6-health-check
   namespaceSelector:
     matchNames:
     - $NAMESPACE

--- a/oci/blackbox-exporter/altinn-uptime/kustomization.yaml
+++ b/oci/blackbox-exporter/altinn-uptime/kustomization.yaml
@@ -183,7 +183,7 @@ patches:
                   preferred_ip_protocol: ip4
                   ip_protocol_fallback: false
                   fail_if_body_not_matches_regexp:
-                    - '^\{"status"\s*:\s*"Healthy"'
+                    - '^\{\s*"status"\s*:\s*"Healthy"'
                   tls_config:
                     insecure_skip_verify: false
               http_health_check_ipv6:
@@ -196,6 +196,6 @@ patches:
                   preferred_ip_protocol: ip6
                   ip_protocol_fallback: false
                   fail_if_body_not_matches_regexp:
-                    - '^\{"status"\s*:\s*"Healthy"'
+                    - '^\{\s*"status"\s*:\s*"Healthy"'
                   tls_config:
                     insecure_skip_verify: false


### PR DESCRIPTION
## Summary

- Adds a new `health_check_ipv4`/`health_check_ipv6` target category to the altinn-uptime sync: these targets are probed with the blackbox `http_health_check_*` modules, which require HTTP 200 **and** a JSON body reporting `"status": "Healthy"` — stricter than the plain 2xx check.
- Moves `https://discore-at23-m22d0r-apim.azure-api.net/dialogporten/health` from the plain 2xx category to the new health check category (the obsolete ServiceMonitor is cleaned up automatically by the sync job) and adds `https://info.at22.altinn.cloud/health` as a new target.
- Fixes the `http_health_check_ipv4/ipv6` module body regexp to tolerate pretty-printed JSON — info.at22 returns formatted JSON that the previous anchored regexp would never match, so its probe would have been permanently failing.
- Verified with `kustomize build` on both packages and an end-to-end run of `generate_targets.sh` against a stubbed kubectl: both new ServiceMonitors render with `module: http_health_check_ipv4`, and both endpoints currently return 200 with a Healthy body.

## Affected packages

- `oci/altinn-uptime`
- `oci/blackbox-exporter`

No changes to `oci/releaseconfig.json` or Release Please config. Rollout note: deploy the blackbox-exporter module update before/with the altinn-uptime target update, otherwise the info.at22 probe alerts as down until the regexp fix lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new health-check monitoring for both IPv4 and IPv6 endpoints.
  * Expanded monitored targets to include additional uptime checks.

* **Bug Fixes**
  * Updated response matching for health checks to be more tolerant of whitespace, reducing false failures.
  * Refreshed target configuration and metadata to the latest version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->