### PR TITLE
feat: update dis operators to latest versions

### DIFF
--- a/oci/dis-identity/base/flux-kustomize.yaml
+++ b/oci/dis-identity/base/flux-kustomize.yaml
@@ -18,7 +18,7 @@ spec:
     - name: controller
       newName: altinncr.azurecr.io/ghcr.io/altinn/altinn-platform/dis-identity-operator
       # renovate: datasource=docker depName=ghcr.io/altinn/altinn-platform/dis-identity-operator versioning=semver
-      newTag: v0.2.0
+      newTag: v0.3.0
   sourceRef:
     kind: OCIRepository
     name: dis-identity-operator

--- a/oci/dis-identity/base/oci-repository.yaml
+++ b/oci/dis-identity/base/oci-repository.yaml
@@ -8,6 +8,6 @@ spec:
   provider: azure
   ref:
     # renovate: datasource=docker depName=ghcr.io/altinn/altinn-platform/dis-identity-operator versioning=semver
-    tag: v0.2.0
+    tag: v0.3.0
   timeout: 5m0s
   url: oci://altinncr.azurecr.io/dis/kustomize/dis-identity-operator

--- a/oci/dis-pgsql/base/flux-kustomize.yaml
+++ b/oci/dis-pgsql/base/flux-kustomize.yaml
@@ -23,7 +23,7 @@ spec:
     - name: controller
       newName: altinncr.azurecr.io/ghcr.io/altinn/altinn-platform/dis-pgsql-operator
       # renovate: datasource=docker depName=ghcr.io/altinn/altinn-platform/dis-pgsql-operator versioning=semver
-      newTag: v0.11.1
+      newTag: v0.12.0
   sourceRef:
     kind: OCIRepository
     name: dis-pgsql-operator

--- a/oci/dis-pgsql/base/oci-repository.yaml
+++ b/oci/dis-pgsql/base/oci-repository.yaml
@@ -8,6 +8,6 @@ spec:
   provider: azure
   ref:
     # renovate: datasource=docker depName=ghcr.io/altinn/altinn-platform/dis-pgsql-operator versioning=semver
-    tag: v0.11.1
+    tag: v0.12.0
   timeout: 5m0s
   url: oci://altinncr.azurecr.io/dis/kustomize/dis-pgsql-operator

--- a/oci/dis-vault/base/flux-kustomize.yaml
+++ b/oci/dis-vault/base/flux-kustomize.yaml
@@ -22,7 +22,7 @@ spec:
     - name: controller
       newName: altinncr.azurecr.io/ghcr.io/altinn/altinn-platform/dis-vault-operator
       # renovate: datasource=docker depName=ghcr.io/altinn/altinn-platform/dis-vault-operator versioning=semver
-      newTag: v1.4.3
+      newTag: v1.4.9
   sourceRef:
     kind: OCIRepository
     name: dis-vault-operator

--- a/oci/dis-vault/base/oci-repository.yaml
+++ b/oci/dis-vault/base/oci-repository.yaml
@@ -8,6 +8,6 @@ spec:
   provider: azure
   ref:
     # renovate: datasource=docker depName=ghcr.io/altinn/altinn-platform/dis-vault-operator versioning=semver
-    tag: v1.4.3
+    tag: v1.4.9
   timeout: 5m0s
   url: oci://altinncr.azurecr.io/dis/kustomize/dis-vault-operator


### PR DESCRIPTION
## Summary

Updates the pinned DIS operator versions to the latest releases published today (2026-07-03), verified against the ghcr.io tags tracked by the Renovate comments and the GitHub releases in Altinn/altinn-platform.

| Operator | From | To |
|----------|------|-----|
| dis-identity-operator | v0.2.0 | v0.3.0 |
| dis-pgsql-operator | v0.11.1 | v0.12.0 |
| dis-vault-operator | v1.4.3 | v1.4.9 |

Each bump updates both version pins per package: the `OCIRepository` `spec.ref.tag` and the controller image `newTag` in the Flux `Kustomization` images override.

## Affected packages

- `oci/dis-identity`
- `oci/dis-pgsql`
- `oci/dis-vault`

No changes to `oci/releaseconfig.json` or Release Please config files.

## Notes for reviewers

- No breaking changes in the release notes. The minor bumps add `status.resourceId` on DatabaseServer/ApplicationIdentity and read-only PostgreSQL debug access on dedicated servers; dis-vault v1.4.9 bumps golang.org/x/net to clear HIGH CVEs.
- `dis-apim` tracks the `latest` tag, so it needs no pin update.
- Validated with `kustomize build` for all three packages; rendered output shows the new tags in both locations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated several operator image versions across the platform, including identity, PostgreSQL, and vault components.
  * These changes move deployments to newer releases for improved stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->