### PR TITLE
chore: remove date suffix from Cloudflare IP update branch name

### DIFF
--- a/.github/workflows/update-cloudflare-ips.yml
+++ b/.github/workflows/update-cloudflare-ips.yml
@@ -54,7 +54,7 @@ jobs:
         if: steps.update.outputs.changed == 'true'
         run: |
           FILE="oci/traefik/multitenancy/lb-source-ranges-configmap.yaml"
-          BRANCH="chore/update-cloudflare-ips-$(date +%Y%m%d)"
+          BRANCH="chore/update-cloudflare-ips"
 
           # Blob SHA of the file on the current branch — required by the Contents API
           FILE_SHA=$(gh api "repos/$GITHUB_REPOSITORY/contents/$FILE" --jq '.sha')


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated Cloudflare IP update process to use a consistent branch name for repeat runs.
  * Repeated updates now open or reuse the same pull request branch, making ongoing maintenance more predictable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->