### PR TITLE
release: deploy version 2.12.0 for the dis-tls-cert config

### DIFF
--- a/oci/releaseconfig.json
+++ b/oci/releaseconfig.json
@@ -88,12 +88,12 @@
     "prod_ring2": "1.3.0"
   },
   "dis-tls-cert": {
-    "at_ring1": "2.11.0",
-    "at_ring2": "2.11.0",
-    "tt_ring1": "2.11.0",
-    "tt_ring2": "2.11.0",
-    "prod_ring1": "2.11.0",
-    "prod_ring2": "2.11.0"
+    "at_ring1": "2.12.0",
+    "at_ring2": "2.12.0",
+    "tt_ring1": "2.12.0",
+    "tt_ring2": "2.12.0",
+    "prod_ring1": "2.12.0",
+    "prod_ring2": "2.12.0"
   },
   "external-secrets-operator": {
     "at_ring1": "1.6.7",


### PR DESCRIPTION
Rolls out the `dis-tls-cert` OCI artifact **2.12.0** to all rings/environments.

Version 2.12.0 was released by Release Please (#1285) and the Flux artifact was built successfully, but `oci/releaseconfig.json` still pinned 2.11.0 everywhere. This bumps all six rings so the new certificate/PushSecret for `skd.apps.yt01.altinn.cloud` (#1284) is actually deployed.

### Affected packages
- `oci/dis-tls-cert`: 2.11.0 → 2.12.0 (at_ring1/2, tt_ring1/2, prod_ring1/2)

### Config changes
- `oci/releaseconfig.json` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated service configuration across all deployment stages to support the latest release.
  * Ensured consistent configuration versions across testing and production environments.
  * No direct user-facing feature changes are included in this update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->