### PR TITLE
feat: Support wildcard domains in dis-tls-cert add-cert script

### DIFF
--- a/oci/dis-tls-cert/add-cert.sh
+++ b/oci/dis-tls-cert/add-cert.sh
@@ -9,11 +9,23 @@ fi
 
 DOMAIN="$1"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-NAME="${DOMAIN//./-}"
+
+# Convert a wildcard prefix to "star" for naming and filenames, e.g.
+# *.apps.tt02.altinn.no -> star.apps.tt02.altinn.no
+# The cert's dnsNames keeps the real wildcard domain.
+SAFE_DOMAIN="${DOMAIN/#\*./star.}"
+NAME="${SAFE_DOMAIN//./-}"
+
+# Wildcard dnsNames must be quoted; a bare YAML scalar starting with * is an alias.
+if [[ "$DOMAIN" == \** ]]; then
+  DNS_NAME="\"${DOMAIN}\""
+else
+  DNS_NAME="${DOMAIN}"
+fi
 
 CERTS_DIR="${SCRIPT_DIR}/certs"
-CERT_FILE="${CERTS_DIR}/${DOMAIN}.yaml"
-PUSH_FILE="${CERTS_DIR}/${DOMAIN}-push.yaml"
+CERT_FILE="${CERTS_DIR}/${SAFE_DOMAIN}.yaml"
+PUSH_FILE="${CERTS_DIR}/${SAFE_DOMAIN}-push.yaml"
 KUSTOMIZATION_FILE="${CERTS_DIR}/kustomization.yaml"
 
 # Available ClusterIssuers
@@ -60,7 +72,7 @@ spec:
     name: ${ISSUER}
     kind: ClusterIssuer
   dnsNames:
-    - ${DOMAIN}
+    - ${DNS_NAME}
 EOF
 
 echo "Created ${CERT_FILE}"
@@ -116,20 +128,20 @@ sedi() {
 }
 
 # Add to kustomization.yaml
-if grep -q "^  - ${DOMAIN}.yaml$" "$KUSTOMIZATION_FILE"; then
-  echo "Already in kustomization.yaml: ${DOMAIN}.yaml"
+if grep -q "^  - ${SAFE_DOMAIN}.yaml$" "$KUSTOMIZATION_FILE"; then
+  echo "Already in kustomization.yaml: ${SAFE_DOMAIN}.yaml"
 else
   sedi "/^resources:$/a\\
-  - ${DOMAIN}.yaml" "$KUSTOMIZATION_FILE"
-  echo "Added ${DOMAIN}.yaml to kustomization.yaml"
+  - ${SAFE_DOMAIN}.yaml" "$KUSTOMIZATION_FILE"
+  echo "Added ${SAFE_DOMAIN}.yaml to kustomization.yaml"
 fi
 
-if grep -q "^  - ${DOMAIN}-push.yaml$" "$KUSTOMIZATION_FILE"; then
-  echo "Already in kustomization.yaml: ${DOMAIN}-push.yaml"
+if grep -q "^  - ${SAFE_DOMAIN}-push.yaml$" "$KUSTOMIZATION_FILE"; then
+  echo "Already in kustomization.yaml: ${SAFE_DOMAIN}-push.yaml"
 else
-  sedi "/^  - ${DOMAIN}.yaml$/a\\
-  - ${DOMAIN}-push.yaml" "$KUSTOMIZATION_FILE"
-  echo "Added ${DOMAIN}-push.yaml to kustomization.yaml"
+  sedi "/^  - ${SAFE_DOMAIN}.yaml$/a\\
+  - ${SAFE_DOMAIN}-push.yaml" "$KUSTOMIZATION_FILE"
+  echo "Added ${SAFE_DOMAIN}-push.yaml to kustomization.yaml"
 fi
 
 echo "Done! Certificate for ${DOMAIN} using ${ISSUER} is ready."

--- a/oci/dis-tls-cert/certs/kustomization.yaml
+++ b/oci/dis-tls-cert/certs/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - star.apps.tt02.altinn.no.yaml
+  - star.apps.tt02.altinn.no-push.yaml
   - skd.apps.yt01.altinn.cloud.yaml
   - skd.apps.yt01.altinn.cloud-push.yaml
   - data.altinn.no.yaml

--- a/oci/dis-tls-cert/certs/star.apps.tt02.altinn.no-push.yaml
+++ b/oci/dis-tls-cert/certs/star.apps.tt02.altinn.no-push.yaml
@@ -1,0 +1,35 @@
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  name: star-apps-tt02-altinn-no-push
+  namespace: dis-tls-cert
+spec:
+  refreshInterval: 1h
+  secretStoreRefs:
+    - name: dis-tls-cert-store
+      kind: SecretStore
+  selector:
+    secret:
+      name: star-apps-tt02-altinn-no
+  template:
+    engineVersion: v2
+    type: kubernetes.io/tls
+    data:
+      tls.crt: '{{ index . "tls.crt" }}'
+      tls.key: '{{ index . "tls.key" }}'
+      pfx_bundle: '{{ fullPemToPkcs12 (index . "tls.crt") (index . "tls.key") | b64dec }}'
+  data:
+    # PEM format for Kubernetes clusters
+    - match:
+        secretKey: tls.crt
+        remoteRef:
+          remoteKey: star-apps-tt02-altinn-no-crt
+    - match:
+        secretKey: tls.key
+        remoteRef:
+          remoteKey: star-apps-tt02-altinn-no-key
+    # PFX format for Azure services
+    - match:
+        secretKey: pfx_bundle
+        remoteRef:
+          remoteKey: cert/star-apps-tt02-altinn-no

--- a/oci/dis-tls-cert/certs/star.apps.tt02.altinn.no.yaml
+++ b/oci/dis-tls-cert/certs/star.apps.tt02.altinn.no.yaml
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: star-apps-tt02-altinn-no
+  namespace: dis-tls-cert
+spec:
+  secretName: star-apps-tt02-altinn-no
+  issuerRef:
+    name: digicert-dis-tls-cert
+    kind: ClusterIssuer
+  dnsNames:
+    - "*.apps.tt02.altinn.no"


### PR DESCRIPTION
Convert wildcard prefix (`*.`) to `star.` for safe filenames and resource names. Properly quote wildcard dnsNames in YAML to avoid alias interpretation. Add certificate for `*.apps.tt02.altinn.no`.