### PR TITLE
fix(platform-system): grant dis-console-reader the DIS and apps groups

### DIFF
--- a/oci/platform-system/dis-console-reader.yaml
+++ b/oci/platform-system/dis-console-reader.yaml
@@ -29,6 +29,51 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - storage.dis.altinn.cloud
+    resources:
+      - databaseservers
+      - databases
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - vault.dis.altinn.cloud
+    resources:
+      - vaults
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - application.dis.altinn.cloud
+    resources:
+      - applicationidentities
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apim.dis.altinn.cloud
+    resources:
+      - apis
+      - apiversions
+      - backends
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+      - statefulsets
+      - daemonsets
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
## Problem

`dis-console-reader` (bound to the dis-console agent's ServiceAccount on the TE fleet) grants only the Flux kinds. The agent has swept the DIS custom resources since v1.4.0 and the fleet runs v1.6.0 — a Forbidden list aborts the entire sweep, so tenant mirrors go stale wherever the dis-* CRDs are installed (dis-pgsql is everywhere). #1160 added the Flux reads; the DIS follow-up never landed.

## Fix

get/list/watch on the four DIS groups (mirroring the admin cluster's `dis-console-flux-reader`) and on `apps` deployments/statefulsets/daemonsets. The apps grant must be in place before the dis-console v1.7.0 agents (workload/images sweep, Altinn/altinn-platform#3836) roll out: core kinds are always served, so there is no skip-if-absent safety and a missing grant aborts the sweep.

## Rollout

Affected package: `oci/platform-system` (read-only grants, `kustomize build` renders clean). Deploy needs the ring bump in `oci/releaseconfig.json` once the release is cut — this should reach the fleet before the dis-console agent image bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)