### PR TITLE
feat(altinn-uptime): add info.altinn.no/health deep health-check probe

### DIFF
--- a/oci/altinn-uptime/configmaps/extra-targets.yaml
+++ b/oci/altinn-uptime/configmaps/extra-targets.yaml
@@ -47,13 +47,14 @@ data:
       ],
       "health_check_ipv4": [
         "https://discore-at23-m22d0r-apim.azure-api.net/dialogporten/health",
-        "https://info.at22.altinn.cloud/health"
+        "https://info.at22.altinn.cloud/health",
+        "https://info.altinn.no/health"
       ],
       "health_check_ipv6": [],
       "metadata": {
         "description": "Extra targets for Altinn monitoring that are not auto-generated from organizations",
         "maintained_by": "Altinn Platform Team",
-        "last_updated": "2026-07-02",
+        "last_updated": "2026-07-29",
         "version": "1.2",
         "notes": [
           "These targets are manually maintained and will be preserved during automatic updates",


### PR DESCRIPTION
## What
Adds `https://info.altinn.no/health` to `health_check_ipv4` in the altinn-uptime extra-targets.

## Why
The prod Infoportal health endpoint was only shallow-probed (root up/TLS). This adds a **deep** blackbox `http_health_check` probe (HTTP 200 + JSON body `status: Healthy`), producing `probe_success{job="blackbox-http-ipv4-health-check", instance="info.altinn.no"}` in `admin-prod-obs-amw`.

## Enables
The Infoportal health-check **availability alert** in `altinn-dashboards-grafana` (companion PR) — routes to Infoportal's Slack.

## Verified
`https://info.altinn.no/health` returns `200 + {"status":"Healthy"}`. Embedded JSON parses; `kustomize build oci/altinn-uptime` OK; target lands in the built ConfigMap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Info Altinn health endpoint to IPv4 health monitoring.

* **Chores**
  * Updated the monitoring configuration’s last-updated date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->