### PR TITLE
feat(dis-tls-cert): Add TLS certificates for platform and wildcard

### DIFF
--- a/oci/dis-tls-cert/certs/kustomization.yaml
+++ b/oci/dis-tls-cert/certs/kustomization.yaml
@@ -1,6 +1,18 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - platform.yt01.altinn.cloud.yaml
+  - platform.yt01.altinn.cloud-push.yaml
+  - platform.at24.altinn.cloud.yaml
+  - platform.at24.altinn.cloud-push.yaml
+  - platform.at23.altinn.cloud.yaml
+  - platform.at23.altinn.cloud-push.yaml
+  - platform.at22.altinn.cloud.yaml
+  - platform.at22.altinn.cloud-push.yaml
+  - platform.tt02.altinn.no.yaml
+  - platform.tt02.altinn.no-push.yaml
+  - star.apps.altinn.no.yaml
+  - star.apps.altinn.no-push.yaml
   - star.apps.tt02.altinn.no.yaml
   - star.apps.tt02.altinn.no-push.yaml
   - skd.apps.yt01.altinn.cloud.yaml

--- a/oci/dis-tls-cert/certs/platform.at22.altinn.cloud-push.yaml
+++ b/oci/dis-tls-cert/certs/platform.at22.altinn.cloud-push.yaml
@@ -1,0 +1,35 @@
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  name: platform-at22-altinn-cloud-push
+  namespace: dis-tls-cert
+spec:
+  refreshInterval: 1h
+  secretStoreRefs:
+    - name: dis-tls-cert-store
+      kind: SecretStore
+  selector:
+    secret:
+      name: platform-at22-altinn-cloud
+  template:
+    engineVersion: v2
+    type: kubernetes.io/tls
+    data:
+      tls.crt: '{{ index . "tls.crt" }}'
+      tls.key: '{{ index . "tls.key" }}'
+      pfx_bundle: '{{ fullPemToPkcs12 (index . "tls.crt") (index . "tls.key") | b64dec }}'
+  data:
+    # PEM format for Kubernetes clusters
+    - match:
+        secretKey: tls.crt
+        remoteRef:
+          remoteKey: platform-at22-altinn-cloud-crt
+    - match:
+        secretKey: tls.key
+        remoteRef:
+          remoteKey: platform-at22-altinn-cloud-key
+    # PFX format for Azure services
+    - match:
+        secretKey: pfx_bundle
+        remoteRef:
+          remoteKey: cert/platform-at22-altinn-cloud

--- a/oci/dis-tls-cert/certs/platform.at22.altinn.cloud.yaml
+++ b/oci/dis-tls-cert/certs/platform.at22.altinn.cloud.yaml
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: platform-at22-altinn-cloud
+  namespace: dis-tls-cert
+spec:
+  secretName: platform-at22-altinn-cloud
+  issuerRef:
+    name: zerossl-dis-tls-cert
+    kind: ClusterIssuer
+  dnsNames:
+    - platform.at22.altinn.cloud

--- a/oci/dis-tls-cert/certs/platform.at23.altinn.cloud-push.yaml
+++ b/oci/dis-tls-cert/certs/platform.at23.altinn.cloud-push.yaml
@@ -1,0 +1,35 @@
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  name: platform-at23-altinn-cloud-push
+  namespace: dis-tls-cert
+spec:
+  refreshInterval: 1h
+  secretStoreRefs:
+    - name: dis-tls-cert-store
+      kind: SecretStore
+  selector:
+    secret:
+      name: platform-at23-altinn-cloud
+  template:
+    engineVersion: v2
+    type: kubernetes.io/tls
+    data:
+      tls.crt: '{{ index . "tls.crt" }}'
+      tls.key: '{{ index . "tls.key" }}'
+      pfx_bundle: '{{ fullPemToPkcs12 (index . "tls.crt") (index . "tls.key") | b64dec }}'
+  data:
+    # PEM format for Kubernetes clusters
+    - match:
+        secretKey: tls.crt
+        remoteRef:
+          remoteKey: platform-at23-altinn-cloud-crt
+    - match:
+        secretKey: tls.key
+        remoteRef:
+          remoteKey: platform-at23-altinn-cloud-key
+    # PFX format for Azure services
+    - match:
+        secretKey: pfx_bundle
+        remoteRef:
+          remoteKey: cert/platform-at23-altinn-cloud

--- a/oci/dis-tls-cert/certs/platform.at23.altinn.cloud.yaml
+++ b/oci/dis-tls-cert/certs/platform.at23.altinn.cloud.yaml
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: platform-at23-altinn-cloud
+  namespace: dis-tls-cert
+spec:
+  secretName: platform-at23-altinn-cloud
+  issuerRef:
+    name: zerossl-dis-tls-cert
+    kind: ClusterIssuer
+  dnsNames:
+    - platform.at23.altinn.cloud

--- a/oci/dis-tls-cert/certs/platform.at24.altinn.cloud-push.yaml
+++ b/oci/dis-tls-cert/certs/platform.at24.altinn.cloud-push.yaml
@@ -1,0 +1,35 @@
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  name: platform-at24-altinn-cloud-push
+  namespace: dis-tls-cert
+spec:
+  refreshInterval: 1h
+  secretStoreRefs:
+    - name: dis-tls-cert-store
+      kind: SecretStore
+  selector:
+    secret:
+      name: platform-at24-altinn-cloud
+  template:
+    engineVersion: v2
+    type: kubernetes.io/tls
+    data:
+      tls.crt: '{{ index . "tls.crt" }}'
+      tls.key: '{{ index . "tls.key" }}'
+      pfx_bundle: '{{ fullPemToPkcs12 (index . "tls.crt") (index . "tls.key") | b64dec }}'
+  data:
+    # PEM format for Kubernetes clusters
+    - match:
+        secretKey: tls.crt
+        remoteRef:
+          remoteKey: platform-at24-altinn-cloud-crt
+    - match:
+        secretKey: tls.key
+        remoteRef:
+          remoteKey: platform-at24-altinn-cloud-key
+    # PFX format for Azure services
+    - match:
+        secretKey: pfx_bundle
+        remoteRef:
+          remoteKey: cert/platform-at24-altinn-cloud

--- a/oci/dis-tls-cert/certs/platform.at24.altinn.cloud.yaml
+++ b/oci/dis-tls-cert/certs/platform.at24.altinn.cloud.yaml
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: platform-at24-altinn-cloud
+  namespace: dis-tls-cert
+spec:
+  secretName: platform-at24-altinn-cloud
+  issuerRef:
+    name: zerossl-dis-tls-cert
+    kind: ClusterIssuer
+  dnsNames:
+    - platform.at24.altinn.cloud

--- a/oci/dis-tls-cert/certs/platform.tt02.altinn.no-push.yaml
+++ b/oci/dis-tls-cert/certs/platform.tt02.altinn.no-push.yaml
@@ -1,0 +1,35 @@
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  name: platform-tt02-altinn-no-push
+  namespace: dis-tls-cert
+spec:
+  refreshInterval: 1h
+  secretStoreRefs:
+    - name: dis-tls-cert-store
+      kind: SecretStore
+  selector:
+    secret:
+      name: platform-tt02-altinn-no
+  template:
+    engineVersion: v2
+    type: kubernetes.io/tls
+    data:
+      tls.crt: '{{ index . "tls.crt" }}'
+      tls.key: '{{ index . "tls.key" }}'
+      pfx_bundle: '{{ fullPemToPkcs12 (index . "tls.crt") (index . "tls.key") | b64dec }}'
+  data:
+    # PEM format for Kubernetes clusters
+    - match:
+        secretKey: tls.crt
+        remoteRef:
+          remoteKey: platform-tt02-altinn-no-crt
+    - match:
+        secretKey: tls.key
+        remoteRef:
+          remoteKey: platform-tt02-altinn-no-key
+    # PFX format for Azure services
+    - match:
+        secretKey: pfx_bundle
+        remoteRef:
+          remoteKey: cert/platform-tt02-altinn-no

--- a/oci/dis-tls-cert/certs/platform.tt02.altinn.no.yaml
+++ b/oci/dis-tls-cert/certs/platform.tt02.altinn.no.yaml
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: platform-tt02-altinn-no
+  namespace: dis-tls-cert
+spec:
+  secretName: platform-tt02-altinn-no
+  issuerRef:
+    name: digicert-dis-tls-cert
+    kind: ClusterIssuer
+  dnsNames:
+    - platform.tt02.altinn.no

--- a/oci/dis-tls-cert/certs/platform.yt01.altinn.cloud-push.yaml
+++ b/oci/dis-tls-cert/certs/platform.yt01.altinn.cloud-push.yaml
@@ -1,0 +1,35 @@
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  name: platform-yt01-altinn-cloud-push
+  namespace: dis-tls-cert
+spec:
+  refreshInterval: 1h
+  secretStoreRefs:
+    - name: dis-tls-cert-store
+      kind: SecretStore
+  selector:
+    secret:
+      name: platform-yt01-altinn-cloud
+  template:
+    engineVersion: v2
+    type: kubernetes.io/tls
+    data:
+      tls.crt: '{{ index . "tls.crt" }}'
+      tls.key: '{{ index . "tls.key" }}'
+      pfx_bundle: '{{ fullPemToPkcs12 (index . "tls.crt") (index . "tls.key") | b64dec }}'
+  data:
+    # PEM format for Kubernetes clusters
+    - match:
+        secretKey: tls.crt
+        remoteRef:
+          remoteKey: platform-yt01-altinn-cloud-crt
+    - match:
+        secretKey: tls.key
+        remoteRef:
+          remoteKey: platform-yt01-altinn-cloud-key
+    # PFX format for Azure services
+    - match:
+        secretKey: pfx_bundle
+        remoteRef:
+          remoteKey: cert/platform-yt01-altinn-cloud

--- a/oci/dis-tls-cert/certs/platform.yt01.altinn.cloud.yaml
+++ b/oci/dis-tls-cert/certs/platform.yt01.altinn.cloud.yaml
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: platform-yt01-altinn-cloud
+  namespace: dis-tls-cert
+spec:
+  secretName: platform-yt01-altinn-cloud
+  issuerRef:
+    name: zerossl-dis-tls-cert
+    kind: ClusterIssuer
+  dnsNames:
+    - platform.yt01.altinn.cloud

--- a/oci/dis-tls-cert/certs/star.apps.altinn.no-push.yaml
+++ b/oci/dis-tls-cert/certs/star.apps.altinn.no-push.yaml
@@ -1,0 +1,35 @@
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  name: star-apps-altinn-no-push
+  namespace: dis-tls-cert
+spec:
+  refreshInterval: 1h
+  secretStoreRefs:
+    - name: dis-tls-cert-store
+      kind: SecretStore
+  selector:
+    secret:
+      name: star-apps-altinn-no
+  template:
+    engineVersion: v2
+    type: kubernetes.io/tls
+    data:
+      tls.crt: '{{ index . "tls.crt" }}'
+      tls.key: '{{ index . "tls.key" }}'
+      pfx_bundle: '{{ fullPemToPkcs12 (index . "tls.crt") (index . "tls.key") | b64dec }}'
+  data:
+    # PEM format for Kubernetes clusters
+    - match:
+        secretKey: tls.crt
+        remoteRef:
+          remoteKey: star-apps-altinn-no-crt
+    - match:
+        secretKey: tls.key
+        remoteRef:
+          remoteKey: star-apps-altinn-no-key
+    # PFX format for Azure services
+    - match:
+        secretKey: pfx_bundle
+        remoteRef:
+          remoteKey: cert/star-apps-altinn-no

--- a/oci/dis-tls-cert/certs/star.apps.altinn.no.yaml
+++ b/oci/dis-tls-cert/certs/star.apps.altinn.no.yaml
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: star-apps-altinn-no
+  namespace: dis-tls-cert
+spec:
+  secretName: star-apps-altinn-no
+  issuerRef:
+    name: digicert-dis-tls-cert
+    kind: ClusterIssuer
+  dnsNames:
+    - "*.apps.altinn.no"


### PR DESCRIPTION
domains

Add cert-manager Certificate and external-secrets PushSecret resources for:
- platform.yt01.altinn.cloud
- platform.at24.altinn.cloud
- platform.at23.altinn.cloud
- platform.at22.altinn.cloud
- platform.tt02.altinn.no
- *.apps.altinn.no