### PR TITLE
feat(dis-tls-cert): Add wildcard certificate for *.altinn.cloud

### DIFF
--- a/oci/dis-tls-cert/certs/kustomization.yaml
+++ b/oci/dis-tls-cert/certs/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - star.altinn.cloud.yaml
+  - star.altinn.cloud-push.yaml
   - platform.yt01.altinn.cloud.yaml
   - platform.yt01.altinn.cloud-push.yaml
   - platform.at24.altinn.cloud.yaml

--- a/oci/dis-tls-cert/certs/star.altinn.cloud-push.yaml
+++ b/oci/dis-tls-cert/certs/star.altinn.cloud-push.yaml
@@ -1,0 +1,35 @@
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  name: star-altinn-cloud-push
+  namespace: dis-tls-cert
+spec:
+  refreshInterval: 1h
+  secretStoreRefs:
+    - name: dis-tls-cert-store
+      kind: SecretStore
+  selector:
+    secret:
+      name: star-altinn-cloud
+  template:
+    engineVersion: v2
+    type: kubernetes.io/tls
+    data:
+      tls.crt: '{{ index . "tls.crt" }}'
+      tls.key: '{{ index . "tls.key" }}'
+      pfx_bundle: '{{ fullPemToPkcs12 (index . "tls.crt") (index . "tls.key") | b64dec }}'
+  data:
+    # PEM format for Kubernetes clusters
+    - match:
+        secretKey: tls.crt
+        remoteRef:
+          remoteKey: star-altinn-cloud-crt
+    - match:
+        secretKey: tls.key
+        remoteRef:
+          remoteKey: star-altinn-cloud-key
+    # PFX format for Azure services
+    - match:
+        secretKey: pfx_bundle
+        remoteRef:
+          remoteKey: cert/star-altinn-cloud

--- a/oci/dis-tls-cert/certs/star.altinn.cloud.yaml
+++ b/oci/dis-tls-cert/certs/star.altinn.cloud.yaml
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: star-altinn-cloud
+  namespace: dis-tls-cert
+spec:
+  secretName: star-altinn-cloud
+  issuerRef:
+    name: zerossl-dis-tls-cert
+    kind: ClusterIssuer
+  dnsNames:
+    - "*.altinn.cloud"


### PR DESCRIPTION
Add Certificate and PushSecret resources to manage the wildcard TLS certificate for *.altinn.cloud domain, including both PEM format for Kubernetes and PFX format for Azure services.