### PR TITLE
feat(dis-tls-cert): add weekly certificate expiry report to Slack

### DIFF
--- a/oci/dis-tls-cert/README.md
+++ b/oci/dis-tls-cert/README.md
@@ -1,5 +1,82 @@
 # dis-tls-cert
 
+Issues TLS certificates with cert-manager and pushes them to the `dis-tls-cert` Azure Key Vault for Azure services to consume.
+
+## Layers
+
+| Path | Description |
+|------|-------------|
+| `base` | Namespace, workload identity ServiceAccount, `SecretStore`, EAB secrets, `ClusterIssuer`s, and `expiry-notify` |
+| `certs` | One `Certificate` + `PushSecret` pair per domain |
+| `expiry-notify` | Weekly `CronJob` that posts Key Vault certificates nearing expiry to Slack — pulled in by `base` |
+
+## Variables
+
+None. No layer in this package uses Flux variable substitution — the only secret the
+`expiry-notify` layer needs is read from Key Vault with an `ExternalSecret`.
+
+## Expiry notifications
+
+`expiry-notify` reads certificate *metadata* from the Key Vault every Monday and reports anything expiring inside
+`WARN_DAYS`, anything already expired, and any certificate with no expiry attribute set. It posts nothing when
+everything is healthy unless `NOTIFY_OK` is set to `true` on the CronJob.
+
+It reads the vault rather than the cluster's `Certificate` resources on purpose: the vault is what Azure services
+actually consume, so this also catches a certificate whose `PushSecret` stopped working, and certificates in the vault
+that no `Certificate` resource manages.
+
+### Slack webhook
+
+The webhook URL lives in the same Key Vault and is synced into the cluster by an `ExternalSecret` through the existing
+`dis-tls-cert-store`, so it never passes through git or Flux substitution vars. The identity already holds Key Vault
+Secrets Officer, so no new role assignment is needed — but the secret has to be created once by hand:
+
+```sh
+az keyvault secret set \
+  --vault-name dis-tls-cert \
+  --name cert-expiry-slack-webhook-url \
+  --value "https://hooks.slack.com/services/..."
+```
+
+The job mounts it as `SLACK_WEBHOOK_URL` from the `dis-tls-cert-expiry-slack-webhook` Secret. If the `ExternalSecret`
+has not synced, the pod will not start and the CronJob reports a failure — which is the intended behaviour.
+
+### When the check itself fails
+
+A failed check posts a `:x:` message to the same channel with the reason attached, so a broken check is not mistaken
+for a clean bill of health. Covered: missing workload identity environment, `az login` failure, a denied or
+unreachable vault, and a vault that returns zero certificates.
+
+Two failures cannot be self-reported, by construction:
+
+- **Slack is unreachable or the webhook was revoked.** The script logs `could not report the failure to Slack either`
+  and exits non-zero, but nothing reaches the channel. Rotating the webhook without updating the vault secret lands
+  here.
+- **The job never runs at all** — not deployed, suspended, deleted, image pull failure, or unschedulable. No code of
+  ours executes, so nothing can report.
+
+Catching those needs a watcher outside this job, e.g. a Grafana alert on
+`kube_cronjob_status_last_successful_time{cronjob="dis-tls-cert-expiry-notify"}` going stale (kube-state-metrics is
+scraped into Azure Managed Prometheus on the admin clusters). Until that exists, a healthy week and a dead job look
+the same in Slack — setting `NOTIFY_OK` to `"true"` on the CronJob at least turns silence into a weekly all-clear.
+
+The job reuses the `dis-tls-cert-kv-uami` ServiceAccount, so it needs no new Azure role assignment — but a workload
+identity federated credential only exists for `admin-prod-aks`, and `base` is only deployed there. If `base` is ever
+rolled out to another cluster, add a federated credential for
+`system:serviceaccount:dis-tls-cert:dis-tls-cert-kv-uami` on that cluster's OIDC issuer first, or the job will fail
+every week — and since failures are reported to Slack, it will say so in the channel.
+
+The default of 21 days is deliberate: cert-manager renews 30 days before expiry, so a 30-day threshold would fire on
+every certificate the moment renewal comes due. 21 days leaves room for renewal plus the hourly `PushSecret` refresh,
+while still giving three weeks of warning.
+
+Verify the message without posting it:
+
+```sh
+kubectl -n dis-tls-cert create job --from=cronjob/dis-tls-cert-expiry-notify expiry-check-manual
+kubectl -n dis-tls-cert logs job/expiry-check-manual
+```
+
 ## Add a certificate
 
 ### Prerequisites

--- a/oci/dis-tls-cert/README.md
+++ b/oci/dis-tls-cert/README.md
@@ -12,8 +12,9 @@ Issues TLS certificates with cert-manager and pushes them to the `dis-tls-cert` 
 
 ## Variables
 
-None. No layer in this package uses Flux variable substitution — the only secret the
-`expiry-notify` layer needs is read from Key Vault with an `ExternalSecret`.
+| Variable | Default | Required | Description |
+|----------|---------|----------|-------------|
+| _none_ | — | No | No layer uses Flux variable substitution. The `expiry-notify` layer reads its only secret from Key Vault with an `ExternalSecret`, and its tunables (`WARN_DAYS`, `NOTIFY_OK`) are plain env values on the CronJob |
 
 ## Expiry notifications
 
@@ -29,31 +30,42 @@ that no `Certificate` resource manages.
 
 The webhook URL lives in the same Key Vault and is synced into the cluster by an `ExternalSecret` through the existing
 `dis-tls-cert-store`, so it never passes through git or Flux substitution vars. The identity already holds Key Vault
-Secrets Officer, so no new role assignment is needed — but the secret has to be created once by hand:
+Secrets Officer, so no new role assignment is needed — but the secret has to be created once by hand.
+
+Write it through a protected temporary file rather than `--value`, so the URL stays out of shell history and the
+process list:
 
 ```sh
+umask 077 && TMP=$(mktemp)
+printf '%s' "https://hooks.slack.com/services/..." > "$TMP"
 az keyvault secret set \
   --vault-name dis-tls-cert \
   --name cert-expiry-slack-webhook-url \
-  --value "https://hooks.slack.com/services/..."
+  --file "$TMP"
+rm -f "$TMP"
 ```
 
-The job mounts it as `SLACK_WEBHOOK_URL` from the `dis-tls-cert-expiry-slack-webhook` Secret. If the `ExternalSecret`
-has not synced, the pod will not start and the CronJob reports a failure — which is the intended behaviour.
+`printf` without a trailing newline matters — a newline inside the URL would break the POST.
+
+The job mounts it as `SLACK_WEBHOOK_URL` from the `dis-tls-cert-expiry-slack-webhook` Secret. If that Secret is missing
+the pod never starts, which is one of the failures the job cannot report itself — see below.
 
 ### When the check itself fails
 
-A failed check posts a `:x:` message to the same channel with the reason attached, so a broken check is not mistaken
-for a clean bill of health. Covered: missing workload identity environment, `az login` failure, a denied or
-unreachable vault, and a vault that returns zero certificates.
+Once the script is running, a failure posts a `:x:` message to the same channel with the reason attached, so a broken
+check is not mistaken for a clean bill of health. Covered: missing workload identity environment, `az login` failure,
+a denied or unreachable vault, and a vault that returns zero certificates.
 
-Two failures cannot be self-reported, by construction:
+Anything that stops the script from starting, or that breaks the channel itself, cannot be self-reported:
 
+- **The webhook Secret is missing or has not synced.** `secretKeyRef` blocks the pod from starting
+  (`CreateContainerConfigError`), so no code of ours runs. The Job is marked failed in Kubernetes, but nothing reaches
+  Slack.
 - **Slack is unreachable or the webhook was revoked.** The script logs `could not report the failure to Slack either`
   and exits non-zero, but nothing reaches the channel. Rotating the webhook without updating the vault secret lands
   here.
-- **The job never runs at all** — not deployed, suspended, deleted, image pull failure, or unschedulable. No code of
-  ours executes, so nothing can report.
+- **The job never runs at all** — not deployed, suspended, deleted, image pull failure, or unschedulable. Again, no
+  code of ours executes.
 
 Catching those needs a watcher outside this job, e.g. a Grafana alert on
 `kube_cronjob_status_last_successful_time{cronjob="dis-tls-cert-expiry-notify"}` going stale (kube-state-metrics is
@@ -70,12 +82,19 @@ The default of 21 days is deliberate: cert-manager renews 30 days before expiry,
 every certificate the moment renewal comes due. 21 days leaves room for renewal plus the hourly `PushSecret` refresh,
 while still giving three weeks of warning.
 
-Verify the message without posting it:
+To run it ad hoc without posting to Slack, inject `DRY_RUN=true` before the Job is created — `create --from=cronjob`
+inherits the CronJob's env, where `DRY_RUN` is unset and therefore `false`, so a plain `create` **does** post:
 
 ```sh
-kubectl -n dis-tls-cert create job --from=cronjob/dis-tls-cert-expiry-notify expiry-check-manual
+kubectl -n dis-tls-cert create job --from=cronjob/dis-tls-cert-expiry-notify expiry-check-manual \
+  --dry-run=client -o yaml \
+  | kubectl set env --local -f - DRY_RUN=true -o yaml \
+  | kubectl apply -f -
 kubectl -n dis-tls-cert logs job/expiry-check-manual
 ```
+
+The log then ends with `DRY_RUN=true, not posting to Slack. Message would be:` followed by the message. Drop the
+`set env` step when you want to verify the Slack path itself.
 
 ## Add a certificate
 

--- a/oci/dis-tls-cert/base/kustomization.yaml
+++ b/oci/dis-tls-cert/base/kustomization.yaml
@@ -7,3 +7,7 @@ resources:
   - digicert-ssl-eabsecret.yaml
   - zero-ssl-eabsecret.yaml
   - clusterissuer.yaml
+  # Weekly Slack report on Key Vault certificates nearing expiry. Included here so
+  # it lands with the ServiceAccount and SecretStore it depends on. Only works on
+  # clusters that have a federated credential for dis-tls-cert-kv-uami.
+  - ../expiry-notify

--- a/oci/dis-tls-cert/expiry-notify/cronjob.yaml
+++ b/oci/dis-tls-cert/expiry-notify/cronjob.yaml
@@ -7,6 +7,9 @@ metadata:
     app.kubernetes.io/name: dis-tls-cert-expiry-notify
 spec:
   schedule: "17 7 * * 1" # Mondays 07:17 UTC
+  # Explicit, so the schedule does not depend on the kube-controller-manager's
+  # local time zone.
+  timeZone: "Etc/UTC"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 1
   failedJobsHistoryLimit: 1

--- a/oci/dis-tls-cert/expiry-notify/cronjob.yaml
+++ b/oci/dis-tls-cert/expiry-notify/cronjob.yaml
@@ -1,0 +1,97 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: dis-tls-cert-expiry-notify
+  namespace: dis-tls-cert
+  labels:
+    app.kubernetes.io/name: dis-tls-cert-expiry-notify
+spec:
+  schedule: "17 7 * * 1" # Mondays 07:17 UTC
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      activeDeadlineSeconds: 300
+      template:
+        metadata:
+          annotations:
+            linkerd.io/inject: disabled
+            cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+          labels:
+            azure.workload.identity/use: "true"
+        spec:
+          # Reuses the identity that already pushes certificates to the vault,
+          # which holds Key Vault Certificates Officer (includes list/get).
+          serviceAccountName: dis-tls-cert-kv-uami
+          automountServiceAccountToken: false
+          restartPolicy: OnFailure
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            fsGroup: 65534
+          containers:
+            - name: check-cert-expiry
+              # Not mirrored through altinncr: there is no mcr.microsoft.com cache
+              # rule on the registry, and the cluster already pulls mcr directly.
+              # renovate: datasource=docker depName=mcr.microsoft.com/azure-cli
+              image: mcr.microsoft.com/azure-cli:2.89.1
+              command:
+                - /bin/bash
+                - /scripts/check_cert_expiry.sh
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
+                runAsUser: 65534
+              env:
+                - name: VAULT_NAME
+                  value: "dis-tls-cert"
+                # Used in the troubleshooting hints in the Slack message.
+                - name: NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: CRONJOB_NAME
+                  value: "dis-tls-cert-expiry-notify"
+                # az needs a writable config dir alongside readOnlyRootFilesystem.
+                - name: AZURE_CONFIG_DIR
+                  value: "/tmp/.azure"
+                - name: AZURE_CORE_COLLECT_TELEMETRY
+                  value: "false"
+                # cert-manager renews 30 days before expiry, so a threshold of 30
+                # would fire on every certificate the moment renewal comes due.
+                # 21 days leaves room for renewal plus the 1h PushSecret refresh.
+                - name: WARN_DAYS
+                  value: "21"
+                # Set to "true" to also post an all-clear, so silence stays meaningful.
+                - name: NOTIFY_OK
+                  value: "false"
+                - name: SLACK_WEBHOOK_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: dis-tls-cert-expiry-slack-webhook
+                      key: SLACK_WEBHOOK_URL
+              volumeMounts:
+                - name: script
+                  mountPath: /scripts
+                - name: workspace
+                  mountPath: /tmp
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 256Mi
+                limits:
+                  cpu: 500m
+                  memory: 512Mi
+          volumes:
+            - name: script
+              configMap:
+                name: dis-tls-cert-check-cert-expiry
+                defaultMode: 0755
+            - name: workspace
+              emptyDir: {}

--- a/oci/dis-tls-cert/expiry-notify/kustomization.yaml
+++ b/oci/dis-tls-cert/expiry-notify/kustomization.yaml
@@ -1,0 +1,22 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: dis-tls-cert
+
+resources:
+  - slack-webhook.yaml
+  - cronjob.yaml
+
+configMapGenerator:
+  - name: dis-tls-cert-check-cert-expiry
+    files:
+      - check_cert_expiry.sh=scripts/check_cert_expiry.sh
+    options:
+      labels:
+        app.kubernetes.io/name: dis-tls-cert-expiry-notify
+        app.kubernetes.io/component: config
+      annotations:
+        # The script uses shell variables ($VAULT_URL, $TEXT, ...). Flux postBuild
+        # substitution would blank every one of them that is not a Flux var, so
+        # substitution must be disabled for this ConfigMap.
+        kustomize.toolkit.fluxcd.io/substitute: disabled

--- a/oci/dis-tls-cert/expiry-notify/scripts/check_cert_expiry.sh
+++ b/oci/dis-tls-cert/expiry-notify/scripts/check_cert_expiry.sh
@@ -1,0 +1,213 @@
+#!/bin/bash
+
+# Check Azure Key Vault for TLS certificates that are about to expire and post a
+# summary to Slack. Silent when everything is healthy, unless NOTIFY_OK=true.
+#
+# Any failure is also reported to Slack, so a broken check is not mistaken for a
+# clean bill of health. The one thing this cannot report is the job never running
+# at all - that needs an external watcher on the CronJob.
+#
+# Reads certificate metadata only, never certificate or key material.
+
+set -euo pipefail
+
+: "${VAULT_NAME:?VAULT_NAME must be set, e.g. dis-tls-cert}"
+: "${SLACK_WEBHOOK_URL:?SLACK_WEBHOOK_URL must be set}"
+
+# Exported so the python steps below can read them.
+export VAULT_NAME
+export WARN_DAYS="${WARN_DAYS:-21}"
+export NOTIFY_OK="${NOTIFY_OK:-false}"
+export DRY_RUN="${DRY_RUN:-false}"
+export CONTEXT="${CONTEXT:-}"
+# Used to build the troubleshooting hints in the Slack message.
+export NAMESPACE="${NAMESPACE:-dis-tls-cert}"
+export CRONJOB_NAME="${CRONJOB_NAME:-dis-tls-cert-expiry-notify}"
+
+# Post a failure notice to the same webhook. Never allowed to fail the script
+# itself: if Slack is the thing that is broken, there is nothing left to try.
+report_failure() {
+    local summary="$1"
+    local detail="${2:-}"
+
+    echo "Reporting failure to Slack: ${summary}" >&2
+    if [ "$DRY_RUN" = "true" ]; then
+        echo "DRY_RUN=true, not posting the failure to Slack" >&2
+        return 0
+    fi
+
+    FAILURE_SUMMARY="$summary" FAILURE_DETAIL="$detail" python3 - <<'PY' || \
+        echo "Error: could not report the failure to Slack either" >&2
+import json
+import os
+import urllib.request
+
+text = (
+    f":x: *TLS certificate expiry check failed* - vault `{os.environ['VAULT_NAME']}`\n"
+    f"{os.environ['FAILURE_SUMMARY']}"
+)
+detail = os.environ["FAILURE_DETAIL"].strip()
+if detail:
+    text += "\n```" + detail[-500:] + "```"
+
+namespace = os.environ["NAMESPACE"]
+cronjob = os.environ["CRONJOB_NAME"]
+text += (
+    "\n*Troubleshoot*\n```"
+    f"kubectl -n {namespace} get jobs\n"
+    f"kubectl -n {namespace} logs job/<failed job>\n"
+    f"kubectl -n {namespace} get externalsecret,secretstore\n"
+    f"kubectl -n {namespace} create job --from=cronjob/{cronjob} expiry-check-manual"
+    "```"
+)
+
+request = urllib.request.Request(
+    os.environ["SLACK_WEBHOOK_URL"],
+    data=json.dumps({"text": text}).encode(),
+    headers={"Content-Type": "application/json"},
+)
+try:
+    urllib.request.urlopen(request, timeout=30).read()
+except Exception as error:  # noqa: BLE001 - last resort, keep the log readable
+    raise SystemExit(f"Error: posting the failure to Slack failed: {error}")
+PY
+}
+
+# AZURE_* are injected by the azure-workload-identity webhook because the pod
+# carries the azure.workload.identity/use: "true" label.
+if [ -z "${AZURE_CLIENT_ID:-}" ] || [ -z "${AZURE_TENANT_ID:-}" ] || [ -z "${AZURE_FEDERATED_TOKEN_FILE:-}" ]; then
+    report_failure "Workload identity environment is missing - is the pod labelled \`azure.workload.identity/use=true\`?"
+    exit 1
+fi
+
+# --allow-no-subscriptions is required: the identity holds vault data-plane roles
+# only, no subscription role.
+echo "Logging in as client ${AZURE_CLIENT_ID}"
+if ! az login --service-principal \
+    --username "${AZURE_CLIENT_ID}" \
+    --tenant "${AZURE_TENANT_ID}" \
+    --federated-token "$(cat "${AZURE_FEDERATED_TOKEN_FILE}")" \
+    --allow-no-subscriptions \
+    --only-show-errors \
+    --output none 2>/tmp/az-login-error.log; then
+    cat /tmp/az-login-error.log >&2
+    report_failure "\`az login\` failed for client \`${AZURE_CLIENT_ID}\` - check the federated credential and its subject." \
+        "$(cat /tmp/az-login-error.log)"
+    exit 1
+fi
+
+# az pages through the vault for us and returns metadata only.
+if ! az keyvault certificate list \
+    --vault-name "$VAULT_NAME" \
+    --only-show-errors \
+    --output json > /tmp/certs.json 2>/tmp/az-list-error.log; then
+    cat /tmp/az-list-error.log >&2
+    report_failure "Listing certificates in \`${VAULT_NAME}\` failed - check the vault firewall and the identity's Key Vault role." \
+        "$(cat /tmp/az-list-error.log)"
+    exit 1
+fi
+
+if ! python3 - <<'PY' 2>/tmp/report-error.log
+import datetime as dt
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+vault = os.environ["VAULT_NAME"]
+warn_days = int(os.environ["WARN_DAYS"])
+context = os.environ["CONTEXT"]
+
+with open("/tmp/certs.json") as f:
+    certs = json.load(f)
+
+# An empty list means the identity lost access or the vault was emptied. Either
+# way it is not an all-clear, so fail loudly instead of reporting silence.
+if not certs:
+    sys.exit(f"Error: no certificates returned from {vault} - refusing to report all-clear")
+
+print(f"Found {len(certs)} certificate(s) in {vault}")
+
+now = dt.datetime.now(dt.timezone.utc)
+expiring = []
+no_expiry = []
+
+for cert in certs:
+    attributes = cert.get("attributes") or {}
+    if attributes.get("enabled") is False:
+        continue
+    name = cert.get("name") or cert.get("id", "").rsplit("/", 1)[-1]
+    expires = attributes.get("expires")
+    if not expires:
+        no_expiry.append(name)
+        continue
+    seconds_left = (dt.datetime.fromisoformat(expires) - now).total_seconds()
+    if seconds_left < warn_days * 86400:
+        expiring.append((seconds_left, name, expires[:10]))
+
+expiring.sort()
+suffix = f" ({context})" if context else ""
+
+if not expiring and not no_expiry:
+    print(f"OK: no certificate in {vault} expires within {warn_days} days")
+    if os.environ["NOTIFY_OK"] != "true":
+        sys.exit(0)
+    text = (
+        f":white_check_mark: *TLS certificates OK* - none of the {len(certs)} "
+        f"certificates in `{vault}`{suffix} expire within {warn_days} days"
+    )
+else:
+    lines = [f":warning: *TLS certificates expiring soon* - vault `{vault}`{suffix}"]
+    for seconds_left, name, expiry_date in expiring:
+        if seconds_left < 0:
+            days_ago = int(-seconds_left // 86400)
+            lines.append(f":rotating_light: `{name}` *expired* {days_ago} days ago ({expiry_date})")
+            print(f"Expired: {name} {days_ago} days ago ({expiry_date})")
+        else:
+            days_left = int(seconds_left // 86400)
+            lines.append(f"- `{name}` expires in {days_left} days ({expiry_date})")
+            print(f"Expiring: {name} in {days_left} days ({expiry_date})")
+    if no_expiry:
+        lines.append(f":grey_question: no expiry set, not monitored: `{', '.join(no_expiry)}`")
+        print("No expiry attribute: " + ", ".join(no_expiry))
+
+    namespace = os.environ["NAMESPACE"]
+    lines.append(
+        "*Troubleshoot* - cert-manager renews 30 days before expiry and the `PushSecret` "
+        "copies the result to the vault within the hour. A name with no `Certificate` here "
+        "is *not* renewed automatically and needs a new certificate."
+    )
+    lines.append(
+        "```"
+        f"kubectl -n {namespace} get certificate,pushsecret\n"
+        f"kubectl -n {namespace} describe certificate <name>"
+        "```"
+    )
+    text = "\n".join(lines)
+
+if os.environ["DRY_RUN"] == "true":
+    print("DRY_RUN=true, not posting to Slack. Message would be:")
+    print(text)
+    sys.exit(0)
+
+request = urllib.request.Request(
+    os.environ["SLACK_WEBHOOK_URL"],
+    data=json.dumps({"text": text}).encode(),
+    headers={"Content-Type": "application/json"},
+)
+try:
+    with urllib.request.urlopen(request, timeout=30) as response:
+        body = response.read().decode().strip()
+except urllib.error.HTTPError as error:
+    sys.exit(f"Error: Slack webhook returned HTTP {error.code}: {error.read().decode().strip()}")
+except urllib.error.URLError as error:
+    sys.exit(f"Error: could not reach Slack webhook: {error.reason}")
+
+print(f"Posted expiry report to Slack ({body})")
+PY
+then
+    cat /tmp/report-error.log >&2
+    report_failure "Building or posting the expiry report failed." "$(cat /tmp/report-error.log)"
+    exit 1
+fi

--- a/oci/dis-tls-cert/expiry-notify/slack-webhook.yaml
+++ b/oci/dis-tls-cert/expiry-notify/slack-webhook.yaml
@@ -1,0 +1,17 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: dis-tls-cert-expiry-slack-webhook
+  namespace: dis-tls-cert
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: SecretStore
+    name: dis-tls-cert-store
+  target:
+    name: dis-tls-cert-expiry-slack-webhook
+    creationPolicy: Owner
+  data:
+    - secretKey: SLACK_WEBHOOK_URL
+      remoteRef:
+        key: cert-expiry-slack-webhook-url

--- a/renovate.json
+++ b/renovate.json
@@ -13,6 +13,15 @@
         "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?: versioning=(?<versioning>\\S+))?\\s*\\n\\s*newTag:\\s*(?<currentValue>v?\\d+\\.\\d+\\.\\d+)",
         "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?: versioning=(?<versioning>\\S+))?\\s*\\n\\s*tag:\\s*(?<currentValue>v?\\d+\\.\\d+\\.\\d+)"
       ]
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^oci\\/dis-tls-cert\\/expiry-notify\\/cronjob\\.yaml$/"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?: versioning=(?<versioning>\\S+))?\\s*\\n\\s*image:\\s*\\S+?:(?<currentValue>v?\\d+\\.\\d+\\.\\d+)"
+      ]
     }
   ],
   "packageRules": [


### PR DESCRIPTION
## Summary

Adds an `expiry-notify` layer to `oci/dis-tls-cert`: a CronJob that runs **Mondays 07:17 UTC** (09:17 Oslo), lists certificate metadata in the `dis-tls-cert` Key Vault with the Azure CLI, and posts anything expiring within **21 days** to `#altinn-alerts-prod`. Silent when everything is healthy.

It reads the **vault** rather than the cluster's `Certificate` resources on purpose: the vault is what Azure services actually consume, so this also catches a certificate whose `PushSecret` stopped working, and certificates in the vault that no `Certificate` resource manages — currently `platform-altinn-no`, which expires 2026-10-13 with nothing renewing it.

The 21-day threshold is deliberate: cert-manager renews 30 days before expiry, so a 30-day threshold would fire on every certificate the moment renewal comes due. 21 days leaves room for renewal plus the hourly `PushSecret` refresh.

## Affected packages

- `oci/dis-tls-cert` — new `expiry-notify/` layer, pulled in by `base/kustomization.yaml`

## Config file changes

- `renovate.json` — new custom manager so the pinned `mcr.microsoft.com/azure-cli` tag in `expiry-notify/cronjob.yaml` gets bumped. No change to `oci/releaseconfig.json` or the Release Please config; this is a `feat` on an existing package, so Release Please will propose a minor bump for `oci-dis-tls-cert`.

## Design notes

- **No new Azure role assignment.** Reuses the `dis-tls-cert-kv-uami` ServiceAccount, which already holds Key Vault Certificates Officer (list/get included).
- **Webhook via ExternalSecret**, read from the same vault through the existing `dis-tls-cert-store`, so it never passes through git or Flux substitution vars.
- **No Flux variable substitution required** by this layer. The generated script ConfigMap carries `kustomize.toolkit.fluxcd.io/substitute: disabled` — `postBuild` substitution would otherwise blank every shell variable inside the embedded script.
- **Failures are reported to Slack** with the underlying error attached, so a broken check is not mistaken for a clean bill of health. Both message types include troubleshooting commands.
- **azure-cli comes from `mcr.microsoft.com` directly** — the registry has no `mcr.microsoft.com` cache rule, and the cluster already pulls dozens of mcr images. Adding an ACR cache rule would let this route through `altinncr` like everything else.

## Deployment prerequisites

1. Create the webhook secret once (**already done** in the `dis-tls-cert` vault as `cert-expiry-slack-webhook-url`).
2. `base` is only deployed on `admin-prod-aks`, the only cluster with a federated credential for `system:serviceaccount:dis-tls-cert:dis-tls-cert-kv-uami`. If `base` is ever rolled out elsewhere, add a federated credential there first, or that cluster will report `az login` failures into the channel weekly.

## Testing

`kustomize build` passes for `base`, `certs` and `expiry-notify`; the ConfigMap hash is identical built either way and the CronJob volume matches. `bash -n` and `shellcheck -S warning` clean. The rendered script in the ConfigMap is byte-identical to the source file.

The script was exercised against the **live vault response** (20 certificates) and a synthetic fixture, with `az` and Slack stubbed:

| Case | Result |
|---|---|
| Nothing expiring | silent, exit 0 |
| Certificates inside the window | one sorted message, exit 0 |
| Already expired / disabled / no expiry attribute | correct handling, disabled skipped |
| `az login` fails | `:x:` + AADSTS error, exit 1 |
| Vault list denied | `:x:` + Forbidden error, exit 1 |
| Vault returns zero certificates | `:x:`, refuses to report all-clear, exit 1 |
| Workload identity env missing | `:x:` + hint, exit 1 |
| Slack unreachable / HTTP 500 | logged, exit 1 |
| `DRY_RUN=true` | posts nothing |

Confirmed the federated token and the webhook URL never appear in a Slack payload.

## What it looks like

Projected first real message, Monday 2026-09-28 (rendered by the script itself with the clock advanced):

```
:warning: *TLS certificates expiring soon* - vault `dis-tls-cert`
- `platform-altinn-no` expires in 15 days (2026-10-13)
*Troubleshoot* - cert-manager renews 30 days before expiry and the `PushSecret` copies the
result to the vault within the hour. A name with no `Certificate` here is *not* renewed
automatically and needs a new certificate.
```

## Follow-ups (not in this PR)

- An external watcher on the CronJob — e.g. a Grafana alert on `kube_cronjob_status_last_successful_time` going stale — is the only thing that catches "the job never ran" or a revoked webhook. Alert rules live in `Altinn/altinn-dashboards-grafana`.
- `NOTIFY_OK: "true"` would turn weekly silence into an explicit all-clear. Left `false`.
- `platform-altinn-no` needs an owner: either bring it into `certs/` so cert-manager manages it, or document who renews it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a weekly check for TLS certificates nearing expiration.
  - Sends certificate status, expiry warnings, and failure notifications to Slack.
  - Automatically synchronizes the Slack webhook securely.
  - Supports dry-run verification and configurable warning thresholds.
  - Runs with restricted security settings and controlled resource usage.

- **Documentation**
  - Added setup, configuration, troubleshooting, workload identity, and manual verification guidance.

- **Chores**
  - Added automated update tracking for the notification workload’s container image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->