### PR TITLE
fix(kube-state-metrics): raise memory limit to 256Mi

### DIFF
--- a/oci/kube-state-metrics/base/helmrelease.yaml
+++ b/oci/kube-state-metrics/base/helmrelease.yaml
@@ -272,4 +272,4 @@ spec:
         cpu: 25m
         memory: 64Mi
       limits:
-        memory: 128Mi
+        memory: 256Mi


### PR DESCRIPTION
## Summary

Raises the kube-state-metrics container memory limit from `128Mi` to `256Mi`. Requests are unchanged (`cpu: 25m`, `memory: 64Mi`).

## Affected packages

- `oci/kube-state-metrics` — `base/helmrelease.yaml`

No changes to `oci/releaseconfig.json` or Release Please config files.

## Validation

- `kustomize build oci/kube-state-metrics` — OK
- `kustomize build oci/kube-state-metrics/multitenancy` — OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)