### PR TITLE
feat(headscale)!: upgrade to headscale 0.29.3

### DIFF
--- a/oci/headscale/README.md
+++ b/oci/headscale/README.md
@@ -26,8 +26,8 @@ metadata:
 data:
   extra-records.json: |
     [
-      {"name": "grafana.ts.altinn.cloud", "type": "A", "value": "100.70.0.3"},
-      {"name": "prometheus.ts.altinn.cloud", "type": "A", "value": "100.70.0.4"}
+      {"name": "grafana.ts.altinn.cloud", "type": "A", "value": "100.64.0.3"},
+      {"name": "prometheus.ts.altinn.cloud", "type": "A", "value": "100.64.0.4"}
     ]
 ```
 

--- a/oci/headscale/config-secret.yaml
+++ b/oci/headscale/config-secret.yaml
@@ -16,7 +16,6 @@ stringData:
       private_key_path: /var/lib/headscale/noise_private.key
     disable_check_updates: true
     ephemeral_node_inactivity_timeout: 180m
-    randomize_client_port: false
     database:
       type: sqlite
       sqlite:
@@ -24,8 +23,8 @@ stringData:
         write_ahead_log: true
         wal_autocheckpoint: 1000
     prefixes:
-      v6: fd7a:115c:a1e0:0070::/64
-      v4: 100.70.0.0/16
+      v6: fd7a:115c:a1e0::/48
+      v4: 100.64.0.0/10
       allocation: sequential
     derp:
       server:

--- a/oci/headscale/deployment.yaml
+++ b/oci/headscale/deployment.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: headscale
           # renovate: datasource=docker depName=juanfont/headscale registryUrl=https://ghcr.io
-          image: altinncr.azurecr.io/ghcr.io/juanfont/headscale:0.28.0
+          image: altinncr.azurecr.io/ghcr.io/juanfont/headscale:0.29.3
           args: ["serve"]
           ports:
             - name: http

--- a/renovate.json
+++ b/renovate.json
@@ -16,12 +16,14 @@
     },
     {
       "customType": "regex",
+      "description": "Container images annotated with a renovate comment, including those pulled through the altinncr.azurecr.io mirror",
       "managerFilePatterns": [
-        "/^oci\\/dis-tls-cert\\/expiry-notify\\/cronjob\\.yaml$/"
+        "/^oci\\/.+\\.ya?ml$/"
       ],
       "matchStrings": [
-        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?: versioning=(?<versioning>\\S+))?\\s*\\n\\s*image:\\s*\\S+?:(?<currentValue>v?\\d+\\.\\d+\\.\\d+)"
-      ]
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+?)(?: registryUrl=(?<registryUrl>\\S+))?(?: versioning=(?<versioning>\\S+))?\\s*\\n\\s*image:\\s*\\S+?:(?<currentValue>v?\\d+\\.\\d+\\.\\d+)"
+      ],
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
     }
   ],
   "packageRules": [
@@ -193,6 +195,20 @@
       ],
       "groupName": "kyverno helm charts",
       "groupSlug": "kyverno-helm"
+    },
+    {
+      "description": "Headscale enforces a strict upgrade path and cannot skip minor versions",
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchPackageNames": [
+        "juanfont/headscale",
+        "ghcr.io/juanfont/headscale"
+      ],
+      "prBodyNotes": [
+        "⚠️ **Headscale blocks skipping minor versions** (e.g. 0.28 → 0.30) and blocks downgrades. Upgrade one minor version at a time.",
+        "Review the BREAKING section of https://github.com/juanfont/headscale/releases for `config.yaml` keys and ACL policy changes before merging."
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

Upgrades **`oci/headscale`** from headscale 0.28.0 to 0.29.3 and restores the IP prefixes to upstream defaults.

Also included: a root-level `renovate.json` fix (second commit). It touches no package path, so release-please ignores it — no version bump or changelog entry from it. Split out on request if you'd rather it went separately.

## Why this wasn't caught by Renovate

The `# renovate:` annotation on the headscale image was decorative — nothing scanned the file:

1. The built-in `kubernetes` manager ships with **no default file pattern**, so it scans zero files unless configured. Neither this repo nor the shared `dis-way/renovate-config` preset configures it.
2. The preset's generic customManager only matches `default:`, `*_VERSION=`, and Helm `version:` forms — never `image: repo:tag`.
3. This repo's `image:` customManager was scoped to `oci/dis-tls-cert/expiry-notify/cronjob.yaml` alone, and had no `registryUrl` capture group, so it would have failed on this annotation regardless.

The fix widens it to `oci/**/*.yaml` and captures `registryUrl`. Verified to match all five annotated images; `renovate-config-validator` passes. This also revives three other silently-dead annotations, so expect Renovate PRs for `headplane`, `activemq`, and `tailscale-subnet-router`.

## Manifest changes

- `deployment.yaml` — image `0.28.0` → `0.29.3`. Targeting the patch rather than 0.29.0: no further config changes, and it carries a registration-auth hardening fix (a leaked auth ID could return the registering user's identity) plus fixes for tagged nodes stuck expired after `tailscale logout`.
- `config-secret.yaml` — removed `randomize_client_port`. **0.29 refuses to start when this key is set**; the toggle moved to the ACL policy as top-level `randomizeClientPort`. It was set to the default (`false`), so no policy-side replacement is needed.
- `config-secret.yaml` — `prefixes.v4`/`v6` restored to the upstream defaults `100.64.0.0/10` and `fd7a:115c:a1e0::/48` (verified against `config-example.yaml` at v0.29.3). The previous `100.70.0.0/16` / `fd7a:115c:a1e0:0070::/64` were copied from a test system.
- `README.md` — example IPs updated to match the default range.

Both new prefixes are **strict supersets** of the old ones, so every already-allocated node address stays valid and nothing is reallocated. This also clears the 0.29 warning about non-standard prefixes, under which `*` in ACLs would have required explicit CIDRs.

## Before rollout

- [ ] **Snapshot the `headscale-data` PVC.** 0.29 migrates the sqlite DB and blocks downgrades, so rollback means restoring the volume, not reverting the tag. (`storageclass.yaml` has `reclaimPolicy: Retain`.)
- [ ] **Review the database-mode ACL policy** with `headscale policy check`. `*` now resolves to the CGNAT/ULA ranges instead of `0.0.0.0/0`; tags, hosts, and IPs are rejected as sources for `autogroup:self` destinations; `proto:icmp` is ICMPv4-only.
- [ ] **Grep ACLs and any external NSG/firewall rules for hardcoded `100.70.0.0/16`.** Existing nodes keep their addresses, but rules scoped to that `/16` will silently miss nodes allocated outside it later.
- [ ] **Confirm clients are on Tailscale v1.80.0+** (new minimum).
- [ ] Note that MagicDNS names change for nodes whose label used the old random-suffix form (`laptop-abc12xyz` → `laptop-1`).
- [ ] Watch startup logs on first rollout to confirm the prefix change is accepted against the existing DB.

0.28 → 0.29 is a single minor step, so headscale's strict upgrade-path guard does not block it.

## Related

`oci/headplane` must move to 0.7.0 alongside this — headplane 0.6.3 predates headscale 0.29 support. Separate PR, since release-please wants one `oci/` package per PR.

## Testing

`kustomize build oci/headscale` and `kustomize build oci/headscale/post-deploy` both render cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)