### PR TITLE
feat(headplane): upgrade to headplane 0.7.0

### DIFF
--- a/oci/headplane/headplane.yaml
+++ b/oci/headplane/headplane.yaml
@@ -26,7 +26,7 @@ spec:
       containers:
         - name: headplane
           # renovate: datasource=docker depName=tale/headplane registryUrl=https://ghcr.io
-          image: altinncr.azurecr.io/ghcr.io/tale/headplane:0.6.3
+          image: altinncr.azurecr.io/ghcr.io/tale/headplane:0.7.0
           imagePullPolicy: Always
           ports:
             - name: http

--- a/oci/headplane/secret.yaml
+++ b/oci/headplane/secret.yaml
@@ -22,7 +22,6 @@ stringData:
       issuer: "https://login.microsoftonline.com/cd0026d8-283b-4a55-9bfa-d0ef4a8ba21c/v2.0"
       client_id: "${HEADPLANE_APP_CLIENT_ID}"
       client_secret: "${HEADPLANE_APP_CLIENT_SECRET}"
-      headscale_api_key: "${HEADPLANE_API_KEY}"
       use_pkce: true
       disable_api_key_login: true
       profile_picture_source: "gravatar"


### PR DESCRIPTION
## Summary

Upgrades **`oci/headplane`** from 0.6.3 to 0.7.0.

Split from #1403 (headscale 0.29.3) because release-please wants one `oci/` package per PR. **Merge #1403 first** — see ordering below.

## Why now

headplane 0.7.0's release notes state it works with **headscale 0.29.0** and requires **0.27.0 or newer**. 0.6.3 predates 0.29 support: it has no handling for 0.29+ registration keys and detects headscale capabilities by hashing the OpenAPI spec rather than reading `/version`.

Relevant fixes in 0.7.0 for this deployment:

- Reworked OIDC authentication and account linking, so OIDC users link to their headscale counterparts more reliably. Fixes existing OIDC users incorrectly dropping into pending-approval after an update.
- Replaced OpenAPI hash detection with `/version`-based capability detection.
- headplane now boots even when headscale is temporarily unreachable, retrying version detection in the background — useful given the `Recreate` rollout on the headscale side.
- Fixed tag handling on headscale 0.28+ and pre-auth key expiration on 0.27.x/0.28+.
- Fixed the DNS page crashing when headscale has no Split DNS nameservers configured.

## Changes

- `headplane.yaml` — image `0.6.3` → `0.7.0`.
- `secret.yaml` — dropped the deprecated `oidc.headscale_api_key`. 0.7.0 consolidates the API key under `headscale.api_key`, which this config already sets to the same value on line 19. The old key is still read as a fallback, so this is a cleanup, not a functional change.

The 0.7.0 notes recommend a re-config since options were consolidated ahead of 1.0. I diffed every remaining key against `config.example.yaml` at `v0.7.0` — `server.host`/`port`/`base_url`/`cookie_secret`/`cookie_secure`/`data_path`, `headscale.url`/`api_key`, and `oidc.issuer`/`client_id`/`client_secret`/`use_pkce`/`disable_api_key_login`/`profile_picture_source` are all still current. No `integration` block is set, so the agent, Docker, Kubernetes, and proc integrations all stay disabled by default.

## Merge order

Merge #1403 (headscale → 0.29.3) first. headplane 0.7.0 supports headscale 0.27+, so running it briefly against 0.28.0 is fine, but the reverse — 0.6.3 against headscale 0.29.3 — is the unsupported combination.

## Testing

`kustomize build oci/headplane` and `kustomize build oci/headplane/post-deploy` both render cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)