### PR TITLE
fix(headscale): migrate config keys removed in 0.29

### DIFF
--- a/oci/headscale/config-secret.yaml
+++ b/oci/headscale/config-secret.yaml
@@ -15,7 +15,12 @@ stringData:
     noise:
       private_key_path: /var/lib/headscale/noise_private.key
     disable_check_updates: true
-    ephemeral_node_inactivity_timeout: 180m
+    node:
+      # Default key expiry for non-tagged nodes, regardless of registration
+      # method. Tagged nodes (exit nodes, subnet routers) are exempt.
+      expiry: 168h # 7 days
+      ephemeral:
+        inactivity_timeout: 180m
     database:
       type: sqlite
       sqlite:
@@ -75,7 +80,6 @@ stringData:
       issuer: "https://login.microsoftonline.com/cd0026d8-283b-4a55-9bfa-d0ef4a8ba21c/v2.0"
       client_id: "${HEADSCALE_APP_CLIENT_ID}"
       client_secret: "${HEADSCALE_APP_CLIENT_SECRET}"
-      expiry: 168h # 7 days
       scope: ["openid", "profile", "email"]
       allowed_groups:
         - "${HEADSCALE_APP_ALLOWED_GROUP}"


### PR DESCRIPTION
## Production is down

`oci-headscale` 2.0.0 (deployed by #1412) is in `CrashLoopBackOff` on `admin-prod-aks`. headscale 0.29.3 refuses to start:

```
FATAL: The "oidc.expiry" configuration key has been removed. Please use "node.expiry" instead.
WARN:  The "ephemeral_node_inactivity_timeout" configuration key is deprecated.
       Please use "node.ephemeral.inactivity_timeout" instead.
```

The embedded DERP relay lives in this pod, so relayed traffic and all new logins and netmap updates are affected. Existing direct peer-to-peer connections are unaffected.

**The database was never migrated.** Config validation runs before the DB is opened, so `Opening database` never appears in any of the restart attempts — the sqlite volume is still on the 0.28 schema.

## Fix

Move both keys under the new `node` block:

```yaml
node:
  expiry: 168h # 7 days
  ephemeral:
    inactivity_timeout: 180m
```

`node.expiry` replaces `oidc.expiry` and applies to every registration method rather than OIDC only, but **tagged nodes are exempt**. Effective behaviour is therefore unchanged here: the exit nodes and subnet routers are tagged, and the user devices that `oidc.expiry` governed register via OIDC.

## Verification

Ran the real binary against the rendered config rather than trusting the release notes:

```
$ podman run ghcr.io/juanfont/headscale:0.29.3 serve -c config.yaml
INF Opening database database=sqlite3
INF starting headscale commit=5aff68b5 version=v0.29.3
INF Clients with a lower minimum version will be rejected minimum_version=v1.80
INF stun server started at [::]:3478
INF derp region: {RegionID:999 RegionCode:headscale-server ...}
INF HA subnet router health probing enabled interval=10000 timeout=5000
```

Passes validation with no deprecation warnings, opens the DB, and starts. Re-adding `oidc.expiry` reproduces the production fatal exactly, so the check is meaningful. (The run then stops on `chmod` of the gRPC unix socket, an artifact of the podman virtiofs mount; in-cluster that path is an `emptyDir`.)

`kustomize build oci/headscale` renders cleanly.

## Why 2.0.0 missed this

I reviewed the 0.29.0 release notes' **BREAKING** section, which lists only `randomize_client_port` under Configuration. `oidc.expiry` and `ephemeral_node_inactivity_timeout` are documented one section further down, under **Changes → Configuration**. For a package that ships a full `config.yaml`, the reliable check is diffing against upstream `config-example.yaml` for the target tag, not reading the breaking-changes list. Worth doing on every headscale bump.

## Rollback alternative

Because the DB is untouched, reverting `oci/releaseconfig.json` to the previous `headscale` config version is also safe and would restore service without waiting on a release cut. That option closes as soon as 0.29.3 starts successfully and migrates the schema, since 0.29 blocks downgrades.

## Follow-up (not in this PR)

0.29 adds `trusted_proxies`, which gates `True-Client-IP` / `X-Real-IP` / `X-Forwarded-For` — previously honoured from any client. The new default (`[]`) ignores them, so headscale will log the Traefik pod IP rather than the real client IP. Set it to the ingress CIDR if the real client IP matters for audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)