### PR TITLE
feat(headscale): trust pod CIDRs for forwarded client IP headers

### DIFF
--- a/oci/headscale/README.md
+++ b/oci/headscale/README.md
@@ -12,6 +12,8 @@ Self-hosted Tailscale control server providing WireGuard-based VPN mesh networki
 | `HEADSCALE_APP_CLIENT_ID` | - | Yes | Microsoft Entra OIDC client ID |
 | `HEADSCALE_APP_CLIENT_SECRET` | - | Yes | Microsoft Entra OIDC client secret — source from a secret store, not plain substitution |
 | `HEADSCALE_APP_ALLOWED_GROUP` | - | Yes | Microsoft Entra group allowed for access |
+| `AKS_POD_IPV4_CIDR` | `10.240.0.0/16` | No | Pod network IPv4 CIDR, trusted for forwarded client-IP headers |
+| `AKS_POD_IPV6_CIDR` | `fd10:59f0:8c79:240::/64` | No | Pod network IPv6 CIDR, trusted for forwarded client-IP headers |
 
 ## Extra DNS Records
 

--- a/oci/headscale/config-secret.yaml
+++ b/oci/headscale/config-secret.yaml
@@ -10,6 +10,13 @@ stringData:
     metrics_listen_addr: "0.0.0.0:9090"
     grpc_listen_addr: "0.0.0.0:50443"
     grpc_allow_insecure: false
+    # CIDRs whose True-Client-IP / X-Real-IP / X-Forwarded-For headers are
+    # honoured. Traefik terminates TLS and forwards through the mesh, so the
+    # peer headscale sees is always a pod address. Without this, remote= logs
+    # the in-cluster proxy instead of the real client.
+    trusted_proxies:
+      - "${AKS_POD_IPV4_CIDR:=10.240.0.0/16}"
+      - "${AKS_POD_IPV6_CIDR:=fd10:59f0:8c79:240::/64}"
     tls_cert_path: ""
     tls_key_path: ""
     noise:


### PR DESCRIPTION
## Summary

headscale 0.29 added `trusted_proxies`, which gates the `True-Client-IP` / `X-Real-IP` / `X-Forwarded-For` headers that earlier versions honoured from **any** client. The new default is empty, so since the 0.29.3 upgrade headscale has been logging the in-cluster proxy address in `remote=` instead of the real client IP.

```yaml
trusted_proxies:
  - "${AKS_POD_IPV4_CIDR:=10.240.0.0/16}"
  - "${AKS_POD_IPV6_CIDR:=fd10:59f0:8c79:240::/64}"
```

Reuses the variable names and defaults already established in `oci/linkerd`, so no change is needed to the Flux `Kustomization` — the defaults are correct for this cluster and remain overridable.

## Why the pod CIDR

Traefik terminates TLS and forwards through the mesh, so the TCP peer headscale sees is always a pod address. Verified on `admin-prod-aks`:

| Pod | IPv4 | IPv6 |
|---|---|---|
| `headscale` | `10.240.5.67` | `fd10:59f0:8c79:240::358` |
| `altinn-traefik` ×3 | `10.240.1.87`, `10.240.3.105`, `10.240.5.106` | `fd10:59f0:8c79:240::{1ba,403,375}` |

This is Azure CNI, so `spec.podCIDRs` is empty on the nodes and there is no narrower per-node range to use. Current logs show `remote=10.240.5.67` — headscale's own pod IP, i.e. the linkerd-proxy sidecar — for real client traffic on `/machine/map` and `/derp`, not just for health probes.

**The pod CIDR is also required for the header parsing to work**, not just for the trust gate. `X-Forwarded-For` is resolved with realclientip's `RightmostTrustedRangeStrategy`, which walks the chain right-to-left and returns the first entry *not* inside `trusted_proxies`. In-cluster hops therefore have to be listed for the real client to be picked out. Prepending a value cannot win, so this is not spoofable from outside.

Header precedence is `True-Client-IP` → `X-Real-IP` → `X-Forwarded-For`. Traefik sets `X-Real-Ip` and `X-Forwarded-For` to the peer it saw, and with `externalTrafficPolicy: Local` (`oci/traefik`, default) plus `forwardedHeaders.insecure: false` scoped to the VNET CIDRs, that peer is the real external client.

For untrusted peers the middleware **strips** all three headers before the handler runs, so this also closes the previous behaviour where any client could set them.

## Scope note

`realIPMiddleware` is mounted with `r.Use(...)` on the whole router, so it rewrites `r.RemoteAddr` for every HTTP handler, not only logging. That is the intent, but it means registration and OIDC flows will now record the real client address too.

## Verification

```
$ podman run ghcr.io/juanfont/headscale:0.29.3 serve -c config.yaml
INF Opening database database=sqlite3
INF starting headscale version=v0.29.3
INF stun server started at [::]:3478
INF HA subnet router health probing enabled
```

Starts clean. Control case — substituting `0.0.0.0/0`:

```
Error: initializing: loading configuration: trusted_proxies[0] "0.0.0.0/0": 0.0.0.0/0 and ::/0 are not allowed
```

so the list is genuinely parsed rather than ignored. `kustomize build oci/headscale` renders cleanly.

## Follow-up

`remote=` should show public client addresses after rollout. If it still shows `10.240.x.x`, the header is not arriving and the Traefik `forwardedHeaders` config for this cluster's overlay is the next thing to check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)